### PR TITLE
FPH go-live branch reconciliation

### DIFF
--- a/apps/web/src/app/chika/[id]/page.tsx
+++ b/apps/web/src/app/chika/[id]/page.tsx
@@ -11,6 +11,7 @@ import type { ChikaCommentView } from "@/features/chika";
 import { commentSchema, type CommentValues } from "@/features/chika/schemas/comment.schema";
 import { getApiErrorMessage, getApiErrorStatus } from "@/lib/http/api-error";
 import { UsernameLink } from "@/components/common/UsernameLink";
+import { ReportAction } from "@/components/report/report-action";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -201,6 +202,7 @@ export default function Chika({ params }: { params: Promise<{ id: string }> }) {
                     {comment.replyCount} repl{comment.replyCount === 1 ? "y" : "ies"}
                   </span>
                 ) : null}
+                <ReportAction targetType="chika_comment" targetId={comment.id} />
                 <Button
                   type="button"
                   variant="ghost"

--- a/apps/web/src/app/groups/[id]/page.tsx
+++ b/apps/web/src/app/groups/[id]/page.tsx
@@ -52,9 +52,6 @@ export default function GroupDetailPage() {
 
   const [postTitle, setPostTitle] = useState("");
   const [postContent, setPostContent] = useState("");
-  const [pendingMembership, setPendingMembership] = useState<
-    "none" | "pending"
-  >("none");
 
   const groupQuery = useGroup(groupId);
   const membersQuery = useGroupMembers(groupId, 1, 20);
@@ -79,11 +76,11 @@ export default function GroupDetailPage() {
     try {
       const membership = await joinMutation.mutateAsync({ groupId });
       if (membership.status === "invited") {
-        setPendingMembership("pending");
-        toast.success("Join request sent. This group requires approval.");
+        toast.error(
+          "Approval queues are not available at launch. Ask a group admin for an invite instead.",
+        );
         return;
       }
-      setPendingMembership("none");
       toast.success("Joined group.");
     } catch (error) {
       toast.error(getApiErrorMessage(error, "Failed to join group"));
@@ -94,7 +91,6 @@ export default function GroupDetailPage() {
     if (!groupId) return;
     try {
       await leaveMutation.mutateAsync({ groupId });
-      setPendingMembership("none");
       toast.success("Left group.");
     } catch (error) {
       toast.error(getApiErrorMessage(error, "Failed to leave group"));
@@ -154,7 +150,8 @@ export default function GroupDetailPage() {
   }
 
   const canJoin =
-    group.visibility !== "invite_only" && group.joinPolicy !== "invite_only";
+    group.visibility !== "invite_only" && group.joinPolicy === "open";
+  const isApprovalOnly = group.joinPolicy === "approval";
 
   return (
     <div className="min-h-full bg-[radial-gradient(circle_at_top_left,_hsl(var(--primary)/0.1),_transparent_26%),linear-gradient(180deg,_hsl(var(--background))_0%,_hsl(var(--muted)/0.24)_100%)] px-4 py-6 sm:px-6 lg:px-8">
@@ -216,7 +213,7 @@ export default function GroupDetailPage() {
                 <CardDescription className="text-sm text-foreground/75">
                   {group.visibility === "public"
                     ? "Public group. Anyone can see members and posts."
-                    : "Restricted group. Content is only visible to members."}
+                    : "Restricted group. Invite-only access is supported at launch; approval queues are not."}
                 </CardDescription>
               </CardHeader>
               <CardContent className="space-y-4">
@@ -229,26 +226,24 @@ export default function GroupDetailPage() {
                       <Button
                         variant="outline"
                         className="w-full"
-                        disabled={leaveMutation.isPending}
-                        onClick={() => void onLeave()}
-                      >
-                        Leave group
-                      </Button>
+                      disabled={leaveMutation.isPending}
+                      onClick={() => void onLeave()}
+                    >
+                      Leave group
+                    </Button>
                     </>
-                  ) : pendingMembership === "pending" ? (
-                    <div className="rounded-3xl border border-border/60 bg-background/80 p-4 text-sm text-foreground/80">
-                      Join request pending.
-                    </div>
                   ) : canJoin ? (
                     <Button
                       className="w-full"
                       disabled={joinMutation.isPending}
                       onClick={() => void onJoin()}
                     >
-                      {group.joinPolicy === "approval"
-                        ? "Request access"
-                        : "Join group"}
+                      Join group
                     </Button>
+                  ) : isApprovalOnly ? (
+                    <div className="rounded-3xl border border-border/60 bg-background/80 p-4 text-sm text-foreground/80">
+                      Approval-based access is not in launch scope yet. Ask a group admin for an invite.
+                    </div>
                   ) : (
                     <div className="rounded-3xl border border-border/60 bg-background/80 p-4 text-sm text-foreground/80">
                       Invite only.
@@ -421,7 +416,7 @@ function visibilityLabel(value: Group["visibility"]) {
 function joinPolicyLabel(value: Group["joinPolicy"]) {
   switch (value) {
     case "approval":
-      return "Approval required";
+      return "Restricted";
     case "invite_only":
       return "Invite only";
     default:

--- a/apps/web/src/app/groups/page.tsx
+++ b/apps/web/src/app/groups/page.tsx
@@ -71,9 +71,8 @@ export default function GroupsPage() {
     "public" | "private" | "invite_only"
   >("public");
   const [createJoinPolicy, setCreateJoinPolicy] = useState<
-    "open" | "approval" | "invite_only"
+    "open" | "invite_only"
   >("open");
-  const [pendingGroupIds, setPendingGroupIds] = useState<string[]>([]);
 
   const filters = useMemo(
     () => ({
@@ -100,15 +99,11 @@ export default function GroupsPage() {
     try {
       const membership = await joinMutation.mutateAsync({ groupId });
       if (membership.status === "invited") {
-        setPendingGroupIds((current) =>
-          current.includes(groupId) ? current : [...current, groupId],
+        toast.error(
+          "Approval queues are not available at launch. Ask a group admin for an invite instead.",
         );
-        toast.success("Join request sent. This group requires approval.");
         return;
       }
-      setPendingGroupIds((current) =>
-        current.filter((item) => item !== groupId),
-      );
       toast.success("Joined group.");
     } catch (error) {
       toast.error(getApiErrorMessage(error, "Failed to join group"));
@@ -118,9 +113,6 @@ export default function GroupsPage() {
   const onLeave = async (groupId: string) => {
     try {
       await leaveMutation.mutateAsync({ groupId });
-      setPendingGroupIds((current) =>
-        current.filter((item) => item !== groupId),
-      );
       toast.success("Left group.");
     } catch (error) {
       toast.error(getApiErrorMessage(error, "Failed to leave group"));
@@ -209,8 +201,8 @@ export default function GroupsPage() {
                   description="Open for anyone to see and join."
                 />
                 <InfoBox
-                  title="Private Groups"
-                  description="Requires approval or invitation to join."
+                  title="Restricted Groups"
+                  description="Invite-only access is supported at launch. Approval queues are not."
                 />
                 {!isSignedIn ? (
                   <SignInButton mode="modal">
@@ -305,16 +297,15 @@ export default function GroupsPage() {
                 />
               ) : (
                 <div className="grid gap-4 lg:grid-cols-2 xl:grid-cols-3">
-                  {discoverGroups.map((group) => (
-                    <GroupCard
-                      key={group.id}
-                      group={group}
-                      isSignedIn={isSignedIn}
-                      isJoined={joinedGroupIds.has(group.id)}
-                      isPending={pendingGroupIds.includes(group.id)}
-                      actionPending={
-                        joinMutation.isPending || leaveMutation.isPending
-                      }
+                    {discoverGroups.map((group) => (
+                      <GroupCard
+                        key={group.id}
+                        group={group}
+                        isSignedIn={isSignedIn}
+                        isJoined={joinedGroupIds.has(group.id)}
+                        actionPending={
+                          joinMutation.isPending || leaveMutation.isPending
+                        }
                       onJoin={() => void onJoin(group.id)}
                       onLeave={() => void onLeave(group.id)}
                     />
@@ -347,7 +338,6 @@ export default function GroupsPage() {
                         group={group}
                         isSignedIn
                         isJoined
-                        isPending={false}
                         actionPending={leaveMutation.isPending}
                         onJoin={() => undefined}
                         onLeave={() => void onLeave(group.id)}
@@ -421,7 +411,7 @@ export default function GroupsPage() {
                   value={createJoinPolicy}
                   onValueChange={(value) =>
                     setCreateJoinPolicy(
-                      value as "open" | "approval" | "invite_only",
+                      value as "open" | "invite_only",
                     )
                   }
                 >
@@ -430,7 +420,6 @@ export default function GroupsPage() {
                   </SelectTrigger>
                   <SelectContent>
                     <SelectItem value="open">Open join</SelectItem>
-                    <SelectItem value="approval">Approval required</SelectItem>
                     <SelectItem value="invite_only">Invite only</SelectItem>
                   </SelectContent>
                 </Select>
@@ -458,7 +447,6 @@ function GroupCard({
   group,
   isSignedIn,
   isJoined,
-  isPending,
   actionPending,
   onJoin,
   onLeave,
@@ -466,14 +454,13 @@ function GroupCard({
   group: Group;
   isSignedIn: boolean;
   isJoined: boolean;
-  isPending: boolean;
   actionPending: boolean;
   onJoin: () => void;
   onLeave: () => void;
 }) {
-  const joinLabel = group.joinPolicy === "approval" ? "Request access" : "Join";
   const canJoin =
-    group.visibility !== "invite_only" && group.joinPolicy !== "invite_only";
+    group.visibility !== "invite_only" && group.joinPolicy === "open";
+  const isApprovalOnly = group.joinPolicy === "approval";
 
   return (
     <Card className="overflow-hidden rounded-[1.75rem] border-border/70 bg-background/80">
@@ -535,7 +522,7 @@ function GroupCard({
           </Link>
           {!isSignedIn ? (
             <SignInButton mode="modal">
-              <Button size="sm">{canJoin ? joinLabel : "Sign in"}</Button>
+              <Button size="sm">{canJoin ? "Join" : "Sign in"}</Button>
             </SignInButton>
           ) : isJoined ? (
             <Button
@@ -546,14 +533,14 @@ function GroupCard({
             >
               Leave
             </Button>
-          ) : isPending ? (
-            <Badge className="rounded-full bg-primary/10 px-3 py-1 text-primary">
-              Request pending
-            </Badge>
           ) : canJoin ? (
             <Button size="sm" disabled={actionPending} onClick={onJoin}>
-              {joinLabel}
+              Join
             </Button>
+          ) : isApprovalOnly ? (
+            <Badge variant="outline" className="rounded-full px-3 py-1">
+              Invite required at launch
+            </Badge>
           ) : (
             <Badge variant="outline" className="rounded-full px-3 py-1">
               Invite only
@@ -641,7 +628,7 @@ function visibilityLabel(value: Group["visibility"]) {
 function joinPolicyLabel(value: Group["joinPolicy"]) {
   switch (value) {
     case "approval":
-      return "Approval required";
+      return "Restricted";
     case "invite_only":
       return "Invite only";
     default:

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -11,7 +11,7 @@ export default async function ProfileRedirectPage() {
   let username: string | null = null;
 
   try {
-    const me = await fphgoFetchServer<MeResponse>(routes.v1.me());
+    const me = await fphgoFetchServer<MeResponse>(routes.v1.session());
     username = me.username ?? null;
   } catch {
     const clerkUser = await currentUser();

--- a/apps/web/src/config/nav.ts
+++ b/apps/web/src/config/nav.ts
@@ -256,6 +256,7 @@ const MAIN_NAV_ORDER: string[] = [
 
 function isVisible(item: NavItem, isSignedIn: boolean): boolean {
   if (item.kind === "action") return true;
+  if (item.comingSoon) return false;
   return isSignedIn || !item.isProtected;
 }
 
@@ -345,7 +346,7 @@ export function isActiveRoute(pathname: string, href: string): boolean {
 }
 
 /** @deprecated Use getVisibleNavItems + getGroupedNavItems. Kept for backward compatibility. */
-export const navigation = NAV_ITEMS.filter((i) => i.kind === "link").map(
+export const navigation = NAV_ITEMS.filter((i) => i.kind === "link" && !i.comingSoon).map(
   (item) => ({
     title: item.title,
     url: item.href ?? "#",

--- a/apps/web/src/features/auth/session/use-session.ts
+++ b/apps/web/src/features/auth/session/use-session.ts
@@ -35,7 +35,7 @@ export function useSession(): SessionState {
     },
     queryFn: async () => {
       const token = await getToken();
-      return apiClient<SharedMeResponse>(routes.v1.me(), { token });
+      return apiClient<SharedMeResponse>(routes.v1.session(), { token });
     },
   });
 

--- a/apps/web/src/features/chika/components/ThreadDetail.tsx
+++ b/apps/web/src/features/chika/components/ThreadDetail.tsx
@@ -1,5 +1,6 @@
 import type { ChikaThreadView } from "../api/threads";
 import { UsernameLink } from "@/components/common/UsernameLink";
+import { ReportAction } from "@/components/report/report-action";
 import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import ThreadActions from "./ThreadActions";
@@ -49,13 +50,14 @@ export default function ThreadDetail({ thread }: ThreadDetailProps) {
         </p>
       ) : null}
 
-      <div className="mt-4">
+      <div className="mt-4 flex flex-wrap items-center gap-2">
         <ThreadActions
           threadId={thread.id}
           initialVoteCount={thread.voteCount}
           initialReaction={thread.userReaction}
           commentCount={thread.commentCount}
         />
+        <ReportAction targetType="chika_thread" targetId={thread.id} />
       </div>
     </Card>
   );

--- a/apps/web/src/features/explore/api/exploreApi.ts
+++ b/apps/web/src/features/explore/api/exploreApi.ts
@@ -1,6 +1,7 @@
-import { apiClient } from "@/lib/api/client";
+import type { ExploreSiteCard } from "@freediving.ph/types";
 
-import { MOCK_EXPLORE_SPOTS } from "../mock-data";
+import { exploreApi as exploreV1Api } from "@/features/diveSpots/api/explore-v1";
+
 import type {
   DiveSpot,
   ExploreBounds,
@@ -8,13 +9,9 @@ import type {
   ExploreSearchParams,
 } from "../types";
 
-const USE_MOCK_EXPLORE_API =
-  process.env.NEXT_PUBLIC_EXPLORE_USE_MOCK !== "false";
-
-const normalize = (value: string) => value.trim().toLowerCase();
-
 const isWithinBounds = (spot: DiveSpot, bounds: ExploreBounds | null) => {
   if (!bounds) return true;
+  if (typeof spot.lat !== "number" || typeof spot.lng !== "number") return false;
   return (
     spot.lat <= bounds.ne.lat &&
     spot.lat >= bounds.sw.lat &&
@@ -23,70 +20,35 @@ const isWithinBounds = (spot: DiveSpot, bounds: ExploreBounds | null) => {
   );
 };
 
-const buildQueryString = (params: ExploreSearchParams) => {
-  const searchParams = new URLSearchParams();
-  if (params.q.trim()) searchParams.set("q", params.q.trim());
-  if (typeof params.minRating === "number")
-    searchParams.set("minRating", String(params.minRating));
-  if (params.tags.length > 0) searchParams.set("tags", params.tags.join(","));
-  if (params.bounds) {
-    searchParams.set(
-      "bounds",
-      [
-        params.bounds.ne.lat.toFixed(5),
-        params.bounds.ne.lng.toFixed(5),
-        params.bounds.sw.lat.toFixed(5),
-        params.bounds.sw.lng.toFixed(5),
-      ].join(","),
-    );
-  }
-  searchParams.set("limit", String(params.limit));
-  searchParams.set("offset", String(params.offset));
-  return searchParams.toString();
-};
-
-const searchMockDiveSpots = async (
-  params: ExploreSearchParams,
-): Promise<ExploreResponse> => {
-  const keyword = normalize(params.q);
-
-  const filtered = MOCK_EXPLORE_SPOTS.filter((spot) => {
-    const matchesKeyword =
-      keyword.length === 0 ||
-      normalize(spot.name).includes(keyword) ||
-      normalize(spot.area).includes(keyword) ||
-      (spot.tags ?? []).some((tag) => normalize(tag).includes(keyword));
-
-    const matchesRating =
-      typeof params.minRating !== "number" ||
-      (spot.rating ?? 0) >= params.minRating;
-
-    const matchesTags =
-      params.tags.length === 0 ||
-      params.tags.every((selectedTag) =>
-        (spot.tags ?? []).includes(selectedTag),
-      );
-
-    return (
-      matchesKeyword &&
-      matchesRating &&
-      matchesTags &&
-      isWithinBounds(spot, params.bounds)
-    );
-  });
-
-  const page = filtered.slice(params.offset, params.offset + params.limit);
-  await new Promise((resolve) => setTimeout(resolve, 250));
-  return { items: page, total: filtered.length };
-};
+const mapSiteCard = (site: ExploreSiteCard): DiveSpot => ({
+  id: site.id,
+  slug: site.slug,
+  name: site.name,
+  area: site.area,
+  lat: site.latitude,
+  lng: site.longitude,
+  difficulty: site.difficulty,
+  verificationStatus: site.verificationStatus,
+  recentUpdateCount: site.recentUpdateCount,
+  lastConditionSummary: site.lastConditionSummary,
+  isSaved: site.isSaved,
+});
 
 export const exploreApi = {
   async searchDiveSpots(params: ExploreSearchParams): Promise<ExploreResponse> {
-    if (USE_MOCK_EXPLORE_API) {
-      return searchMockDiveSpots(params);
-    }
+    const response = await exploreV1Api.listSites({
+      search: params.q.trim() || undefined,
+      cursor: params.cursor,
+      limit: params.limit,
+    });
 
-    const queryString = buildQueryString(params);
-    return apiClient<ExploreResponse>(`/explore/dive-spots?${queryString}`);
+    const items = response.items
+      .map(mapSiteCard)
+      .filter((spot) => isWithinBounds(spot, params.bounds));
+
+    return {
+      items,
+      nextCursor: response.nextCursor,
+    };
   },
 };

--- a/apps/web/src/features/explore/components/DiveSpotCard.tsx
+++ b/apps/web/src/features/explore/components/DiveSpotCard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { MapPin, Star, X } from "lucide-react";
+import { MapPin, Waves, X } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -86,35 +86,42 @@ export const DiveSpotCard = React.forwardRef<HTMLDivElement, DiveSpotCardProps>(
                   <h3 className="line-clamp-2 text-base font-semibold text-foreground">
                     {spot.name}
                   </h3>
-                  {typeof spot.rating === "number" ? (
-                    <div className="flex items-center gap-1 rounded-full bg-amber-50 px-2 py-1 text-xs font-medium text-amber-700">
-                      <Star className="size-3.5 fill-current" />
-                      {spot.rating.toFixed(1)}
-                    </div>
-                  ) : null}
                 </div>
                 <p className="text-muted-foreground flex items-center gap-1.5 text-sm">
                   <MapPin className="size-4" />
                   {spot.area}
                 </p>
-                {typeof spot.reviewCount === "number" ? (
-                  <p className="text-muted-foreground text-xs">
-                    {spot.reviewCount.toLocaleString()} reviews
-                  </p>
-                ) : null}
+                <div className="flex flex-wrap gap-2">
+                  <Badge
+                    variant="secondary"
+                    className="rounded-full bg-muted px-2.5 py-1 text-xs capitalize"
+                  >
+                    {spot.difficulty}
+                  </Badge>
+                  <Badge
+                    variant="outline"
+                    className="rounded-full px-2.5 py-1 text-xs capitalize"
+                  >
+                    {spot.verificationStatus}
+                  </Badge>
+                  {spot.recentUpdateCount > 0 ? (
+                    <Badge
+                      variant="outline"
+                      className="rounded-full px-2.5 py-1 text-xs"
+                    >
+                      <Waves className="mr-1.5 size-3.5" />
+                      {spot.recentUpdateCount} recent update
+                      {spot.recentUpdateCount === 1 ? "" : "s"}
+                    </Badge>
+                  ) : null}
+                </div>
               </div>
 
-              <div className="flex flex-wrap gap-2">
-                {(spot.tags ?? []).slice(0, 4).map((tag) => (
-                  <Badge
-                    key={tag}
-                    variant="secondary"
-                    className="rounded-full bg-muted px-2.5 py-1 text-xs"
-                  >
-                    {tag}
-                  </Badge>
-                ))}
-              </div>
+              {spot.lastConditionSummary ? (
+                <p className="text-sm text-muted-foreground">
+                  {spot.lastConditionSummary}
+                </p>
+              ) : null}
 
               {actions ? (
                 <div

--- a/apps/web/src/features/explore/components/ExploreLayout.tsx
+++ b/apps/web/src/features/explore/components/ExploreLayout.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import { useInfiniteQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   Check,
   Compass,
@@ -10,7 +10,6 @@ import {
   Heart,
   MapPinned,
   Share2,
-  SlidersHorizontal,
 } from "lucide-react";
 import { useDeferredValue, useEffect, useMemo, useRef, useState } from "react";
 
@@ -18,18 +17,6 @@ import { Badge } from "@/components/ui/badge";
 import { Button, buttonVariants } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover";
-import {
-  Sheet,
-  SheetContent,
-  SheetDescription,
-  SheetHeader,
-  SheetTitle,
-} from "@/components/ui/sheet";
 import { Tabs, TabsContent, TabsList } from "@/components/ui/tabs";
 import { cn } from "@/lib/utils";
 import { MapProvider } from "@/providers/map-provider";
@@ -37,11 +24,11 @@ import { useSidebar } from "@/components/ui/sidebar";
 import { useSession } from "@/features/auth/session";
 
 import { exploreApi } from "../api/exploreApi";
+import { exploreApi as exploreWriteApi } from "@/features/diveSpots/api/explore-v1";
 import { useMapBounds } from "../hooks/useMapBounds";
 import { useExploreQueryState } from "../hooks/useExploreQueryState";
 import {
   EXPLORE_DEFAULT_LIMIT,
-  EXPLORE_TAG_OPTIONS,
   type DiveSpot,
   getDiveSpotSlug,
 } from "../types";
@@ -50,159 +37,80 @@ import { ExploreMap } from "./ExploreMap";
 import { ExploreMobileToggle } from "./ExploreMobileToggle";
 import { ExploreResultsPanel } from "./ExploreResultsPanel";
 
-type SortMode = "relevance" | "rating" | "reviews";
+type SortMode = "relevance" | "recent";
 
 const sortItems = (items: DiveSpot[], sort: SortMode) => {
   switch (sort) {
-    case "rating":
+    case "recent":
       return [...items].sort(
-        (left, right) => (right.rating ?? 0) - (left.rating ?? 0),
-      );
-    case "reviews":
-      return [...items].sort(
-        (left, right) => (right.reviewCount ?? 0) - (left.reviewCount ?? 0),
+        (left, right) => right.recentUpdateCount - left.recentUpdateCount,
       );
     default:
       return items;
   }
 };
 
-function FilterContent({
-  minRating,
-  tags,
-  onSelectRating,
-  onToggleTag,
-  onReset,
-}: {
-  minRating: number | null;
-  tags: string[];
-  onSelectRating: (rating: number | null) => void;
-  onToggleTag: (tag: string) => void;
-  onReset: () => void;
-}) {
-  return (
-    <div className="space-y-5">
-      <div className="space-y-3">
-        <div className="flex items-center justify-between">
-          <p className="text-sm font-semibold">Minimum rating</p>
-          <Button variant="ghost" size="sm" onClick={onReset}>
-            Reset
-          </Button>
-        </div>
-        <div className="grid grid-cols-3 gap-2">
-          {[
-            { label: "Any", value: null },
-            { label: "4.0+", value: 4 },
-            { label: "4.5+", value: 4.5 },
-          ].map((option) => {
-            const active = minRating === option.value;
-            return (
-              <Button
-                key={option.label}
-                variant={active ? "default" : "outline"}
-                className="rounded-full"
-                onClick={() => onSelectRating(option.value)}
-              >
-                {option.label}
-              </Button>
-            );
-          })}
-        </div>
-      </div>
-
-      <div className="space-y-3">
-        <p className="text-sm font-semibold">Tags</p>
-        <div className="flex flex-wrap gap-2">
-          {EXPLORE_TAG_OPTIONS.map((tag) => {
-            const active = tags.includes(tag);
-            return (
-              <Button
-                key={tag}
-                variant={active ? "default" : "outline"}
-                className="rounded-full"
-                onClick={() => onToggleTag(tag)}
-              >
-                {active ? <Check className="mr-1.5 size-4" /> : null}
-                {tag}
-              </Button>
-            );
-          })}
-        </div>
-      </div>
-    </div>
-  );
-}
-
 export function ExploreLayout() {
   const session = useSession();
+  const queryClient = useQueryClient();
   const { setOpen, setOpenMobile } = useSidebar();
   const didForceSidebarCloseRef = useRef(false);
   const searchInputRef = useRef<HTMLInputElement>(null);
-  const [mobileFiltersOpen, setMobileFiltersOpen] = useState(false);
   const [sort, setSort] = useState<SortMode>("relevance");
-  const [savedSpotIds, setSavedSpotIds] = useState<string[]>([]);
 
   const {
     state,
     resetFilters,
     setBounds,
     setCamera,
-    setMinRating,
     setQuery,
     setSelectedSpot,
     setView,
-    toggleTag,
   } = useExploreQueryState();
 
   const deferredQuery = useDeferredValue(state.q);
   const boundsState = useMapBounds(state.bounds);
 
-  const exploreQuery = useQuery({
+  const exploreQuery = useInfiniteQuery({
     queryKey: [
       "explore",
       {
         q: deferredQuery,
-        minRating: state.minRating,
-        tags: state.tags,
         bounds: state.bounds,
         limit: EXPLORE_DEFAULT_LIMIT,
-        offset: 0,
       },
     ],
-    queryFn: () =>
+    queryFn: ({ pageParam }: { pageParam?: string }) =>
       exploreApi.searchDiveSpots({
         q: deferredQuery,
-        minRating: state.minRating,
-        tags: state.tags,
         bounds: state.bounds,
         limit: EXPLORE_DEFAULT_LIMIT,
-        offset: 0,
+        cursor: pageParam,
       }),
-    placeholderData: keepPreviousData,
+    initialPageParam: undefined as string | undefined,
+    getNextPageParam: (lastPage) => lastPage.nextCursor || undefined,
   });
+  const saveSiteMutation = useMutation({
+    mutationFn: async ({ siteId, isSaved }: { siteId: string; isSaved: boolean }) => {
+      if (isSaved) {
+        await exploreWriteApi.unsaveSite(siteId);
+        return;
+      }
+      await exploreWriteApi.saveSite(siteId);
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["explore"] });
+    },
+  });
+  const exploreItems =
+    exploreQuery.data?.pages.flatMap((page) => page.items) ?? [];
 
   const sortedItems = useMemo(
-    () => sortItems(exploreQuery.data?.items ?? [], sort),
-    [exploreQuery.data?.items, sort],
+    () => sortItems(exploreItems, sort),
+    [exploreItems, sort],
   );
   const selectedSpot =
     sortedItems.find((spot) => spot.id === state.selectedSpotId) ?? null;
-
-  useEffect(() => {
-    const saved = window.localStorage.getItem("explore-saved-spots");
-    if (!saved) return;
-
-    try {
-      const parsed = JSON.parse(saved);
-      if (Array.isArray(parsed)) {
-        setSavedSpotIds(
-          parsed.filter((value): value is string => typeof value === "string"),
-        );
-      }
-    } catch {
-      window.localStorage.removeItem("explore-saved-spots");
-    }
-  }, []);
 
   useEffect(() => {
     if (didForceSidebarCloseRef.current) return;
@@ -232,17 +140,6 @@ export function ExploreLayout() {
     setSelectedSpot(null);
   };
 
-  const toggleSavedSpot = (spotId: string) => {
-    setSavedSpotIds((current) => {
-      const next = current.includes(spotId)
-        ? current.filter((id) => id !== spotId)
-        : [...current, spotId];
-
-      window.localStorage.setItem("explore-saved-spots", JSON.stringify(next));
-      return next;
-    });
-  };
-
   const shareSpot = async (spot: DiveSpot) => {
     const url = `${window.location.origin}/explore/sites/${getDiveSpotSlug(spot)}`;
     if (navigator.share) {
@@ -254,7 +151,7 @@ export function ExploreLayout() {
   };
 
   const renderSpotActions = (spot: DiveSpot) => {
-    const isSaved = savedSpotIds.includes(spot.id);
+    const isSaved = spot.isSaved;
 
     return (
       <>
@@ -273,58 +170,26 @@ export function ExploreLayout() {
           <Share2 className="mr-1.5 size-4" />
           Share
         </Button>
-        <Button
-          size="sm"
-          variant={isSaved ? "default" : "outline"}
-          className="rounded-full"
-          onClick={() => toggleSavedSpot(spot.id)}
-        >
-          <Heart className={cn("mr-1.5 size-4", isSaved && "fill-current")} />
-          {isSaved ? "Saved" : "Save"}
-        </Button>
+        {session.status === "signed_in" ? (
+          <Button
+            size="sm"
+            variant={isSaved ? "default" : "outline"}
+            className="rounded-full"
+            disabled={saveSiteMutation.isPending}
+            onClick={() =>
+              saveSiteMutation.mutate({
+                siteId: spot.id,
+                isSaved,
+              })
+            }
+          >
+            <Heart className={cn("mr-1.5 size-4", isSaved && "fill-current")} />
+            {isSaved ? "Saved" : "Save"}
+          </Button>
+        ) : null}
       </>
     );
   };
-
-  const filterContent = (
-    <FilterContent
-      minRating={state.minRating}
-      tags={state.tags}
-      onSelectRating={setMinRating}
-      onToggleTag={toggleTag}
-      onReset={handleResetFilters}
-    />
-  );
-
-  const desktopFiltersControl = (
-    <Popover>
-      <PopoverTrigger
-        render={
-          <Button
-            variant="outline"
-            size="icon"
-            className="size-11 rounded-full"
-            aria-label="Open filters"
-          />
-        }
-      >
-        <SlidersHorizontal className="size-4.5" />
-      </PopoverTrigger>
-      <PopoverContent>{filterContent}</PopoverContent>
-    </Popover>
-  );
-
-  const mobileFiltersControl = (
-    <Button
-      variant="outline"
-      size="icon"
-      className="size-11 rounded-full"
-      onClick={() => setMobileFiltersOpen(true)}
-      aria-label="Open filters"
-    >
-      <SlidersHorizontal className="size-4.5" />
-    </Button>
-  );
 
   return (
     <MapProvider>
@@ -364,14 +229,17 @@ export function ExploreLayout() {
         <div className="hidden h-full lg:grid lg:grid-cols-[460px_minmax(0,1fr)]">
           <ExploreResultsPanel
             q={state.q}
-            total={exploreQuery.data?.total ?? 0}
-            loading={exploreQuery.isLoading}
+            total={sortedItems.length}
+            loading={exploreQuery.isPending}
             fetching={exploreQuery.isFetching}
             spots={sortedItems}
             selectedSpotId={state.selectedSpotId}
+            hasNextPage={Boolean(exploreQuery.hasNextPage)}
+            isFetchingNextPage={exploreQuery.isFetchingNextPage}
             searchInputRef={searchInputRef}
-            filtersControl={desktopFiltersControl}
+            filtersControl={null}
             onQueryChange={setQuery}
+            onLoadMore={() => void exploreQuery.fetchNextPage()}
             onSelectSpot={handleSelectSpot}
             sort={sort}
             onSortChange={setSort}
@@ -401,21 +269,6 @@ export function ExploreLayout() {
               </Button>
             </div>
 
-            <div className="absolute bottom-5 left-5 flex flex-wrap gap-2">
-              {state.minRating ? (
-                <Badge className="rounded-full bg-card/90 px-3 py-1 text-foreground shadow">
-                  {state.minRating.toFixed(1)}+ rated
-                </Badge>
-              ) : null}
-              {state.tags.map((tag) => (
-                <Badge
-                  key={tag}
-                  className="rounded-full bg-card/90 px-3 py-1 text-foreground shadow"
-                >
-                  {tag}
-                </Badge>
-              ))}
-            </div>
           </div>
         </div>
 
@@ -440,7 +293,6 @@ export function ExploreLayout() {
                   aria-label="Search dive spots"
                   className="h-11 rounded-full bg-muted/40"
                 />
-                {mobileFiltersControl}
               </div>
             </Card>
 
@@ -491,13 +343,16 @@ export function ExploreLayout() {
           <TabsContent value="list" className="mt-0 min-h-0 flex-1">
             <ExploreResultsPanel
               q={state.q}
-              total={exploreQuery.data?.total ?? 0}
-              loading={exploreQuery.isLoading}
+              total={sortedItems.length}
+              loading={exploreQuery.isPending}
               fetching={exploreQuery.isFetching}
               spots={sortedItems}
               selectedSpotId={state.selectedSpotId}
-              filtersControl={mobileFiltersControl}
+              hasNextPage={Boolean(exploreQuery.hasNextPage)}
+              isFetchingNextPage={exploreQuery.isFetchingNextPage}
+              filtersControl={null}
               onQueryChange={setQuery}
+              onLoadMore={() => void exploreQuery.fetchNextPage()}
               onSelectSpot={handleSelectSpot}
               sort={sort}
               onSortChange={setSort}
@@ -509,18 +364,6 @@ export function ExploreLayout() {
             />
           </TabsContent>
         </Tabs>
-
-        <Sheet open={mobileFiltersOpen} onOpenChange={setMobileFiltersOpen}>
-          <SheetContent side="bottom" className="rounded-t-[32px] pb-8">
-            <SheetHeader className="px-4 pb-2">
-              <SheetTitle>Filters</SheetTitle>
-              <SheetDescription>
-                Refine the map and list with shared query state.
-              </SheetDescription>
-            </SheetHeader>
-            <div className="px-4">{filterContent}</div>
-          </SheetContent>
-        </Sheet>
       </div>
       <div className="relative">
         <div className="pointer-events-none fixed lg:hidden inset-x-0 bottom-20 z-50 flex justify-center px-4">

--- a/apps/web/src/features/explore/components/ExploreLayout.tsx
+++ b/apps/web/src/features/explore/components/ExploreLayout.tsx
@@ -43,6 +43,7 @@ import {
   EXPLORE_DEFAULT_LIMIT,
   EXPLORE_TAG_OPTIONS,
   type DiveSpot,
+  getDiveSpotSlug,
 } from "../types";
 import { DiveSpotCard } from "./DiveSpotCard";
 import { ExploreMap } from "./ExploreMap";
@@ -243,7 +244,7 @@ export function ExploreLayout() {
   };
 
   const shareSpot = async (spot: DiveSpot) => {
-    const url = `${window.location.origin}/explore/sites/${spot.id}`;
+    const url = `${window.location.origin}/explore/sites/${getDiveSpotSlug(spot)}`;
     if (navigator.share) {
       await navigator.share({ title: spot.name, url });
       return;
@@ -257,7 +258,7 @@ export function ExploreLayout() {
 
     return (
       <>
-        <Link href={`/explore/sites/${spot.id}`}>
+        <Link href={`/explore/sites/${getDiveSpotSlug(spot)}`}>
           <Button size="sm" variant="outline" className="rounded-full">
             <ExternalLink className="mr-1.5 size-4" />
             Open site

--- a/apps/web/src/features/explore/components/ExploreMap.tsx
+++ b/apps/web/src/features/explore/components/ExploreMap.tsx
@@ -57,6 +57,14 @@ function ExploreMarkers({
   const map = useMap();
   const clustererRef = useRef<MarkerClusterer | null>(null);
   const markersRef = useRef(new globalThis.Map<string, google.maps.Marker>());
+  const spotsWithCoordinates = useMemo(
+    () =>
+      spots.filter(
+        (spot): spot is DiveSpot & { lat: number; lng: number } =>
+          typeof spot.lat === "number" && typeof spot.lng === "number",
+      ),
+    [spots],
+  );
 
   useEffect(() => {
     if (!map || clustererRef.current) return;
@@ -68,7 +76,7 @@ function ExploreMarkers({
   useEffect(() => {
     if (!map || !clustererRef.current) return;
 
-    const nextIds = new Set(spots.map((spot) => spot.id));
+    const nextIds = new Set(spotsWithCoordinates.map((spot) => spot.id));
 
     for (const [spotId, marker] of markersRef.current.entries()) {
       if (!nextIds.has(spotId)) {
@@ -78,7 +86,7 @@ function ExploreMarkers({
       }
     }
 
-    for (const spot of spots) {
+    for (const spot of spotsWithCoordinates) {
       const currentMarker = markersRef.current.get(spot.id);
       const icon = {
         url: markerSvg(spot.id === selectedSpotId),
@@ -104,7 +112,7 @@ function ExploreMarkers({
 
     clustererRef.current.clearMarkers();
     clustererRef.current.addMarkers(Array.from(markersRef.current.values()));
-  }, [map, onSelectSpot, selectedSpotId, spots]);
+  }, [map, onSelectSpot, selectedSpotId, spotsWithCoordinates]);
 
   useEffect(() => {
     if (!selectedSpotId || !map) return;

--- a/apps/web/src/features/explore/components/ExploreResultsPanel.tsx
+++ b/apps/web/src/features/explore/components/ExploreResultsPanel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useRef } from "react";
-import { ArrowUpWideNarrow } from "lucide-react";
+import { ArrowUpWideNarrow, LoaderCircle } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -18,7 +18,7 @@ import { cn } from "@/lib/utils";
 import type { DiveSpot } from "../types";
 import { DiveSpotCard } from "./DiveSpotCard";
 
-type SortMode = "relevance" | "rating" | "reviews";
+type SortMode = "relevance" | "recent";
 
 type ExploreResultsPanelProps = {
   q: string;
@@ -27,9 +27,12 @@ type ExploreResultsPanelProps = {
   fetching: boolean;
   spots: DiveSpot[];
   selectedSpotId: string | null;
+  hasNextPage: boolean;
+  isFetchingNextPage: boolean;
   searchInputRef?: React.RefObject<HTMLInputElement | null>;
   filtersControl: React.ReactNode;
   onQueryChange: (q: string) => void;
+  onLoadMore: () => void;
   onSelectSpot: (spot: DiveSpot) => void;
   sort: SortMode;
   onSortChange: (sort: SortMode) => void;
@@ -42,8 +45,7 @@ type ExploreResultsPanelProps = {
 
 const sortLabels: Record<SortMode, string> = {
   relevance: "Relevance",
-  rating: "Top rated",
-  reviews: "Most reviewed",
+  recent: "Recent updates",
 };
 
 export function ExploreResultsPanel({
@@ -53,9 +55,12 @@ export function ExploreResultsPanel({
   fetching,
   spots,
   selectedSpotId,
+  hasNextPage,
+  isFetchingNextPage,
   searchInputRef,
   filtersControl,
   onQueryChange,
+  onLoadMore,
   onSelectSpot,
   sort,
   onSortChange,
@@ -125,11 +130,8 @@ export function ExploreResultsPanel({
                 <DropdownMenuItem onClick={() => onSortChange("relevance")}>
                   Relevance
                 </DropdownMenuItem>
-                <DropdownMenuItem onClick={() => onSortChange("rating")}>
-                  Top rated
-                </DropdownMenuItem>
-                <DropdownMenuItem onClick={() => onSortChange("reviews")}>
-                  Most reviewed
+                <DropdownMenuItem onClick={() => onSortChange("recent")}>
+                  Recent updates
                 </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>
@@ -167,11 +169,8 @@ export function ExploreResultsPanel({
                 <DropdownMenuItem onClick={() => onSortChange("relevance")}>
                   Relevance
                 </DropdownMenuItem>
-                <DropdownMenuItem onClick={() => onSortChange("rating")}>
-                  Top rated
-                </DropdownMenuItem>
-                <DropdownMenuItem onClick={() => onSortChange("reviews")}>
-                  Most reviewed
+                <DropdownMenuItem onClick={() => onSortChange("recent")}>
+                  Recent updates
                 </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>
@@ -229,6 +228,26 @@ export function ExploreResultsPanel({
               </Button>
             </div>
           )}
+          {hasResults && hasNextPage ? (
+            <div className="flex justify-center px-2 pb-2">
+              <Button
+                type="button"
+                variant="outline"
+                className="rounded-full"
+                onClick={onLoadMore}
+                disabled={isFetchingNextPage}
+              >
+                {isFetchingNextPage ? (
+                  <>
+                    <LoaderCircle className="mr-2 size-4 animate-spin" />
+                    Loading more
+                  </>
+                ) : (
+                  "Load more sites"
+                )}
+              </Button>
+            </div>
+          ) : null}
         </div>
       </ScrollArea>
     </div>

--- a/apps/web/src/features/explore/mock-data.ts
+++ b/apps/web/src/features/explore/mock-data.ts
@@ -1,4 +1,4 @@
-import type { DiveSpot } from "./types";
+import { getDiveSpotSlug, type DiveSpot } from "./types";
 
 export const MOCK_EXPLORE_SPOTS: DiveSpot[] = [
   {
@@ -244,4 +244,4 @@ export const MOCK_EXPLORE_SPOTS: DiveSpot[] = [
 ];
 
 export const getMockDiveSpotBySlug = (slug: string) =>
-  MOCK_EXPLORE_SPOTS.find((spot) => spot.id === slug) ?? null;
+  MOCK_EXPLORE_SPOTS.find((spot) => getDiveSpotSlug(spot) === slug) ?? null;

--- a/apps/web/src/features/explore/mock-data.ts
+++ b/apps/web/src/features/explore/mock-data.ts
@@ -1,6 +1,11 @@
 import { getDiveSpotSlug, type DiveSpot } from "./types";
 
-export const MOCK_EXPLORE_SPOTS: DiveSpot[] = [
+type MockDiveSpotSeed = Pick<
+  DiveSpot,
+  "id" | "name" | "area" | "lat" | "lng" | "rating" | "reviewCount" | "tags"
+>;
+
+const MOCK_EXPLORE_SPOT_SEEDS: MockDiveSpotSeed[] = [
   {
     id: "anilao-cathedral",
     name: "Cathedral Rock",
@@ -242,6 +247,17 @@ export const MOCK_EXPLORE_SPOTS: DiveSpot[] = [
     tags: ["Drift", "Reef", "Boat"],
   },
 ];
+
+export const MOCK_EXPLORE_SPOTS: DiveSpot[] = MOCK_EXPLORE_SPOT_SEEDS.map(
+  (spot) => ({
+    ...spot,
+    slug: spot.id,
+    difficulty: "moderate",
+    verificationStatus: "community",
+    recentUpdateCount: 0,
+    isSaved: false,
+  }),
+);
 
 export const getMockDiveSpotBySlug = (slug: string) =>
   MOCK_EXPLORE_SPOTS.find((spot) => getDiveSpotSlug(spot) === slug) ?? null;

--- a/apps/web/src/features/explore/types.ts
+++ b/apps/web/src/features/explore/types.ts
@@ -2,6 +2,7 @@ export type MapViewMode = "map" | "list";
 
 export type DiveSpot = {
   id: string;
+  slug?: string;
   name: string;
   area: string;
   lat: number;
@@ -63,6 +64,8 @@ export const PHILIPPINES_CENTER = {
 export const PHILIPPINES_ZOOM = 5.6;
 
 export const EXPLORE_DEFAULT_LIMIT = 48;
+
+export const getDiveSpotSlug = (spot: DiveSpot): string => spot.slug ?? spot.id;
 
 export const EXPLORE_TAG_OPTIONS = [
   "Beginner",

--- a/apps/web/src/features/explore/types.ts
+++ b/apps/web/src/features/explore/types.ts
@@ -2,11 +2,16 @@ export type MapViewMode = "map" | "list";
 
 export type DiveSpot = {
   id: string;
-  slug?: string;
+  slug: string;
   name: string;
   area: string;
-  lat: number;
-  lng: number;
+  lat?: number;
+  lng?: number;
+  difficulty: "easy" | "moderate" | "hard";
+  verificationStatus: "community" | "instructor" | "moderator" | "verified";
+  recentUpdateCount: number;
+  lastConditionSummary?: string;
+  isSaved: boolean;
   rating?: number;
   reviewCount?: number;
   coverImageUrl?: string;
@@ -15,7 +20,7 @@ export type DiveSpot = {
 
 export type ExploreResponse = {
   items: DiveSpot[];
-  total: number;
+  nextCursor?: string;
 };
 
 export type ExploreBounds = {
@@ -39,11 +44,9 @@ export type ExploreCamera = {
 
 export type ExploreSearchParams = {
   q: string;
-  minRating: number | null;
-  tags: string[];
   bounds: ExploreBounds | null;
   limit: number;
-  offset: number;
+  cursor?: string;
 };
 
 export type ExploreQueryState = {
@@ -65,7 +68,7 @@ export const PHILIPPINES_ZOOM = 5.6;
 
 export const EXPLORE_DEFAULT_LIMIT = 48;
 
-export const getDiveSpotSlug = (spot: DiveSpot): string => spot.slug ?? spot.id;
+export const getDiveSpotSlug = (spot: DiveSpot): string => spot.slug;
 
 export const EXPLORE_TAG_OPTIONS = [
   "Beginner",

--- a/apps/web/src/features/messages/api/messages.ts
+++ b/apps/web/src/features/messages/api/messages.ts
@@ -2,6 +2,7 @@ import type {
   MessagingMarkReadRequest,
   MessagingMarkReadResponse,
   MessagingOpenDirectThreadRequest,
+  MessagingResolveThreadRequestResponse,
   MessagingSendMessageRequest,
   MessagingSendMessageResponse,
   MessagingThreadDetailResponse,
@@ -57,6 +58,18 @@ export const messagesApi = {
     return fphgoFetchClient<MessagingMarkReadResponse>(routes.v1.messages.threadRead(threadId), {
       method: "POST",
       body: payload as unknown as Record<string, unknown>,
+    });
+  },
+
+  acceptThreadRequest: async (threadId: string): Promise<MessagingResolveThreadRequestResponse> => {
+    return fphgoFetchClient<MessagingResolveThreadRequestResponse>(routes.v1.messages.threadAccept(threadId), {
+      method: "POST",
+    });
+  },
+
+  declineThreadRequest: async (threadId: string): Promise<MessagingResolveThreadRequestResponse> => {
+    return fphgoFetchClient<MessagingResolveThreadRequestResponse>(routes.v1.messages.threadDecline(threadId), {
+      method: "POST",
     });
   },
 

--- a/apps/web/src/features/messages/components/MessagingView.tsx
+++ b/apps/web/src/features/messages/components/MessagingView.tsx
@@ -16,7 +16,7 @@ import { UserAvatarDetail } from "@/components/ui/user-avatar-detail";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { useSession } from "@/features/auth/session/use-session";
 
-import { useMarkThreadRead, useSendThreadMessage } from "../hooks/mutations";
+import { useMarkThreadRead, useResolveThreadRequest, useSendThreadMessage } from "../hooks/mutations";
 import { useThreadDetail, useThreadList, useThreadMessages } from "../hooks/queries";
 import { useMessagesRealtime } from "../hooks/realtime";
 
@@ -110,6 +110,7 @@ export function MessagingView({ threadId }: { threadId: string | null }) {
 
   const sendMutation = useSendThreadMessage(session.me?.userId);
   const markReadMutation = useMarkThreadRead();
+  const resolveRequestMutation = useResolveThreadRequest();
   const serverLastReadMessageId = threadDetailQuery.data?.lastReadMessageId;
 
   useEffect(() => {
@@ -175,6 +176,7 @@ export function MessagingView({ threadId }: { threadId: string | null }) {
 
   const showOfflineBanner = !realtime.networkOnline;
   const showRealtimeLagBanner = realtime.networkOnline && realtime.connectionStatus !== "connected";
+  const isActionableRequest = Boolean(threadDetailQuery.data?.activeRequest && threadDetailQuery.data?.canResolveRequest);
 
   const inboxPanel = (
     <div className="flex h-full min-h-0 flex-col border-r border-border bg-card">
@@ -282,7 +284,47 @@ export function MessagingView({ threadId }: { threadId: string | null }) {
           displayName={partner?.displayName || partner?.username || "Conversation"}
           username={partner?.username || "unknown"}
         />
+        {isActionableRequest ? (
+          <Badge variant="outline" className="ml-auto">Message request</Badge>
+        ) : null}
       </div>
+
+      {isActionableRequest ? (
+        <div className="border-b border-border bg-amber-50 px-4 py-3">
+          <p className="text-sm font-medium text-amber-900">This conversation is still in your requests inbox.</p>
+          <p className="mt-1 text-xs text-amber-800">
+            Accept to move it into normal messaging. Decline hides it from your inbox until a new direct thread is opened again.
+          </p>
+          <div className="mt-3 flex gap-2">
+            <Button
+              onClick={() => {
+                if (!activeThreadId) return;
+                resolveRequestMutation.mutate({ threadId: activeThreadId, action: "accept" });
+              }}
+              disabled={resolveRequestMutation.isPending}
+            >
+              Accept
+            </Button>
+            <Button
+              variant="outline"
+              onClick={() => {
+                if (!activeThreadId) return;
+                resolveRequestMutation.mutate(
+                  { threadId: activeThreadId, action: "decline" },
+                  {
+                    onSuccess: () => {
+                      router.replace("/messages?tab=requests");
+                    },
+                  },
+                );
+              }}
+              disabled={resolveRequestMutation.isPending}
+            >
+              Decline
+            </Button>
+          </div>
+        </div>
+      ) : null}
 
       {showOfflineBanner ? (
         <div className="border-b border-destructive/40 bg-destructive/10 px-4 py-2 text-xs text-destructive">
@@ -332,22 +374,26 @@ export function MessagingView({ threadId }: { threadId: string | null }) {
       </div>
 
       <div className="border-t border-border bg-card p-3">
-        <div className="flex items-end gap-2">
-          <Textarea
-            rows={1}
-            value={composer}
-            onChange={(event) => setComposer(event.target.value)}
-            onKeyDown={(event) => {
-              if (event.key === "Enter" && !event.shiftKey) {
-                event.preventDefault();
-                handleSend();
-              }
-            }}
-            placeholder="Message..."
-            className="min-h-10 resize-none"
-          />
-          <Button onClick={handleSend} disabled={!composer.trim() || sendMutation.isPending}>Send</Button>
-        </div>
+        {threadDetailQuery.data?.canSend ? (
+          <div className="flex items-end gap-2">
+            <Textarea
+              rows={1}
+              value={composer}
+              onChange={(event) => setComposer(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter" && !event.shiftKey) {
+                  event.preventDefault();
+                  handleSend();
+                }
+              }}
+              placeholder="Message..."
+              className="min-h-10 resize-none"
+            />
+            <Button onClick={handleSend} disabled={!composer.trim() || sendMutation.isPending}>Send</Button>
+          </div>
+        ) : (
+          <p className="text-sm text-muted-foreground">Accept this request before you can reply.</p>
+        )}
       </div>
     </div>
   );

--- a/apps/web/src/features/messages/hooks/mutations.ts
+++ b/apps/web/src/features/messages/hooks/mutations.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import type {
   MessagingMarkReadResponse,
+  MessagingResolveThreadRequestResponse,
   MessagingSendMessageResponse,
   MessagingThreadMessage,
   MessagingThreadMessagesResponse,
@@ -146,6 +147,24 @@ export const useUpdateThreadCategory = () => {
       messagesApi.updateThreadCategory(threadId, { category }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["messages", "threads"] });
+    },
+  });
+};
+
+export const useResolveThreadRequest = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ threadId, action }: { threadId: string; action: "accept" | "decline" }) =>
+      action === "accept" ? messagesApi.acceptThreadRequest(threadId) : messagesApi.declineThreadRequest(threadId),
+    onSuccess: (data: MessagingResolveThreadRequestResponse, variables: { threadId: string; action: "accept" | "decline" }) => {
+      queryClient.invalidateQueries({ queryKey: ["messages", "threads"] });
+      if (variables.action === "decline") {
+        queryClient.removeQueries({ queryKey: messageQueryKeys.thread(data.threadId) });
+        queryClient.removeQueries({ queryKey: messageQueryKeys.threadMessages(data.threadId) });
+        return;
+      }
+      queryClient.invalidateQueries({ queryKey: messageQueryKeys.thread(data.threadId) });
+      queryClient.invalidateQueries({ queryKey: messageQueryKeys.threadMessages(data.threadId) });
     },
   });
 };

--- a/apps/web/src/features/profile/components/ProfileTabs.tsx
+++ b/apps/web/src/features/profile/components/ProfileTabs.tsx
@@ -1,10 +1,6 @@
 "use client";
 
-import { useState } from "react";
-import { Bookmark, Clapperboard, Grid3X3, Tag } from "lucide-react";
-
 import { Separator } from "@/components/ui/separator";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { ProfileGrid } from "@/features/profile/components/ProfileGrid";
 import type { ProfileMediaItem } from "@freediving.ph/types";
 
@@ -19,21 +15,6 @@ type ProfileTabsProps = {
   avatarUrl?: string;
 };
 
-function PlaceholderPanel({
-  title,
-  description,
-}: {
-  title: string;
-  description: string;
-}) {
-  return (
-    <div className="flex min-h-72 flex-col items-center justify-center gap-3 text-center">
-      <p className="text-base font-semibold text-foreground">{title}</p>
-      <p className="max-w-sm text-sm text-muted-foreground">{description}</p>
-    </div>
-  );
-}
-
 export function ProfileTabs({
   mediaItems,
   isLoadingMedia,
@@ -44,77 +25,21 @@ export function ProfileTabs({
   displayName,
   avatarUrl,
 }: ProfileTabsProps) {
-  const [tab, setTab] = useState("grid");
-
   return (
     <section className="space-y-0">
       <Separator />
-      <Tabs value={tab} onValueChange={setTab} className="gap-0">
-          <TabsList
-            variant="line"
-            className="grid w-full h-12! grid-cols-4 gap-0 rounded-none px-0"
-          >
-            <TabsTrigger
-              value="grid"
-              className="rounded-none py-3 text-xs uppercase tracking-[0.18em]"
-            >
-              <Grid3X3 className="size-4" />
-              <span className="hidden sm:inline">Grid</span>
-            </TabsTrigger>
-            <TabsTrigger
-              value="videos"
-              className="rounded-none py-3 text-xs uppercase tracking-[0.18em]"
-            >
-              <Clapperboard className="size-4" />
-              <span className="hidden sm:inline">Videos</span>
-            </TabsTrigger>
-            <TabsTrigger
-              value="saved"
-              className="rounded-none py-3 text-xs uppercase tracking-[0.18em]"
-            >
-              <Bookmark className="size-4" />
-              <span className="hidden sm:inline">Saved</span>
-            </TabsTrigger>
-            <TabsTrigger
-              value="tagged"
-              className="rounded-none py-3 text-xs uppercase tracking-[0.18em]"
-            >
-              <Tag className="size-4" />
-              <span className="hidden sm:inline">Tagged</span>
-            </TabsTrigger>
-          </TabsList>
-
-        <TabsContent value="grid" className="pt-2 px-1">
-          <ProfileGrid
-            items={mediaItems}
-            isLoading={isLoadingMedia}
-            hasNextPage={hasNextPage}
-            isFetchingNextPage={isFetchingNextPage}
-            onLoadMore={onLoadMore}
-            username={username}
-            displayName={displayName}
-            avatarUrl={avatarUrl}
-          />
-        </TabsContent>
-        <TabsContent value="videos" className="pt-4">
-          <PlaceholderPanel
-            title="Videos coming soon"
-            description="Reels-style profile video playback is not wired yet."
-          />
-        </TabsContent>
-        <TabsContent value="saved" className="pt-4">
-          <PlaceholderPanel
-            title="Saved coming soon"
-            description="Private saved profile collections will land after the grid flow is stable."
-          />
-        </TabsContent>
-        <TabsContent value="tagged" className="pt-4">
-          <PlaceholderPanel
-            title="Tagged coming soon"
-            description="Tagged post discovery is a placeholder until that feed contract exists."
-          />
-        </TabsContent>
-      </Tabs>
+      <div className="px-1 pt-2">
+        <ProfileGrid
+          items={mediaItems}
+          isLoading={isLoadingMedia}
+          hasNextPage={hasNextPage}
+          isFetchingNextPage={isFetchingNextPage}
+          onLoadMore={onLoadMore}
+          username={username}
+          displayName={displayName}
+          avatarUrl={avatarUrl}
+        />
+      </div>
     </section>
   );
 }

--- a/apps/web/src/lib/api/fphgo-routes.ts
+++ b/apps/web/src/lib/api/fphgo-routes.ts
@@ -3,7 +3,7 @@ const toPathId = (id: string | number): string =>
 
 export const routes = {
   v1: {
-    me: () => "/v1/auth/session",
+    session: () => "/v1/auth/session",
     messages: {
       threads: () => "/v1/messages/threads",
       threadById: (threadId: string | number) =>

--- a/apps/web/src/lib/api/fphgo-routes.ts
+++ b/apps/web/src/lib/api/fphgo-routes.ts
@@ -12,6 +12,10 @@ export const routes = {
         `/v1/messages/threads/${toPathId(threadId)}/messages`,
       threadRead: (threadId: string | number) =>
         `/v1/messages/threads/${toPathId(threadId)}/read`,
+      threadAccept: (threadId: string | number) =>
+        `/v1/messages/threads/${toPathId(threadId)}/accept`,
+      threadDecline: (threadId: string | number) =>
+        `/v1/messages/threads/${toPathId(threadId)}/decline`,
       threadCategory: (threadId: string | number) =>
         `/v1/messages/threads/${toPathId(threadId)}/category`,
       directThread: () => "/v1/messages/threads/direct",

--- a/apps/web/test/fphgo-ci-smoke.test.mjs
+++ b/apps/web/test/fphgo-ci-smoke.test.mjs
@@ -42,7 +42,7 @@ test("GET /readyz — DB readiness check", async () => {
 // ── Auth gate: unauthenticated requests are rejected ────────────────
 
 test("protected endpoints return 401 without auth", async () => {
-  const paths = ["/v1/me", "/v1/blocks", "/v1/buddies"];
+  const paths = ["/v1/auth/session", "/v1/blocks", "/v1/buddies"];
   for (const path of paths) {
     const { response, body } = await request(path);
     assert.equal(response.status, 401, `expected 401 for ${path}`);
@@ -52,8 +52,8 @@ test("protected endpoints return 401 without auth", async () => {
 
 // ── Identity bootstrap + session ────────────────────────────────────
 
-test("GET /v1/me — session with dev auth harness", async () => {
-  const { response, body } = await authedRequest("/v1/me");
+test("GET /v1/auth/session — canonical session with dev auth harness", async () => {
+  const { response, body } = await authedRequest("/v1/auth/session");
   assert.equal(response.status, 200);
   assert.equal(body.clerkSubject, SMOKE_USER);
   assert.equal(typeof body.userId, "string");
@@ -62,6 +62,14 @@ test("GET /v1/me — session with dev auth harness", async () => {
   assert.equal(body.accountStatus, "active");
   assert.equal(Array.isArray(body.permissions), true);
   assert.ok(body.permissions.length > 0, "member should have permissions");
+});
+
+test("GET /v1/me — legacy session alias remains readable", async () => {
+  const { response, body } = await authedRequest("/v1/me");
+  assert.equal(response.status, 200);
+  assert.equal(response.headers.get("deprecation"), "true");
+  assert.equal(response.headers.get("link"), '</v1/auth/session>; rel="successor-version"');
+  assert.equal(body.clerkSubject, SMOKE_USER);
 });
 
 // ── Migrated feature: blocks ────────────────────────────────────────

--- a/docs/go-live/fph-execution-log.md
+++ b/docs/go-live/fph-execution-log.md
@@ -207,3 +207,20 @@
 - Pushed: pending
 - Blockers:
   - none
+
+## 2026-03-31 23:35 Asia/Manila — FRO-198
+
+- Status: completed on shared branch, awaiting review
+- Branch: `fix/fph-go-live`
+- Worktree: `/Volumes/Files/softwareengineering/my-projects/freedivingph-go-live`
+- Summary: added a repo-backed launch smoke checklist that separates what is already automated from what still requires real deploy-time/manual verification. The checklist is grounded in the current route surface and explicitly calls out that dev-auth smoke is not enough to prove production Clerk or media behavior.
+- Files touched:
+  - `docs/go-live/fph-launch-smoke-checklist.md`
+  - `docs/go-live/fph-execution-log.md`
+- Verification:
+  - `rg -n "Automated Smoke Already In Repo|Manual Launch Smoke|Navigation Truth|Known Limits Of This Checklist" docs/go-live/fph-launch-smoke-checklist.md`
+  - reviewed `apps/web/test/fphgo-ci-smoke.test.mjs`, `services/fphgo/internal/app/routes.go`, and feature route files to ground checklist steps in current repo truth
+- Commit hash: pending
+- Pushed: pending
+- Blockers:
+  - real production smoke execution still depends on deploy-time Clerk and media environment; this ticket documents the path and gates instead of faking runtime evidence

--- a/docs/go-live/fph-execution-log.md
+++ b/docs/go-live/fph-execution-log.md
@@ -36,3 +36,17 @@
   - `pnpm --filter @freediving.ph/web type-check`
 - Commit hash: recorded in Git history for `fix/fph-go-live`
 - Blockers: none
+
+## 2026-03-31 19:49 Asia/Manila — FRO-190
+
+- Status: completed locally on shared branch, awaiting explicit push/review
+- Branch: `fix/fph-go-live`
+- Worktree: `/Volumes/Files/softwareengineering/my-projects/freedivingph-go-live`
+- Summary: removed the fake profile tabs so launch scope only exposes the real profile media grid.
+- Files touched:
+  - `apps/web/src/features/profile/components/ProfileTabs.tsx`
+  - `docs/go-live/fph-execution-log.md`
+- Verification:
+  - `pnpm --filter @freediving.ph/web type-check`
+- Commit hash: recorded in Git history for `fix/fph-go-live`
+- Blockers: none

--- a/docs/go-live/fph-execution-log.md
+++ b/docs/go-live/fph-execution-log.md
@@ -50,3 +50,19 @@
   - `pnpm --filter @freediving.ph/web type-check`
 - Commit hash: recorded in Git history for `fix/fph-go-live`
 - Blockers: none
+
+## 2026-03-31 20:00 Asia/Manila — FRO-194
+
+- Status: completed locally on shared branch, awaiting explicit push/review
+- Branch: `fix/fph-go-live`
+- Worktree: `/Volumes/Files/softwareengineering/my-projects/freedivingph-go-live`
+- Summary: aligned Explore site links and share URLs to a dedicated slug helper so the route layer no longer implicitly treats `id` as the public slug contract.
+- Files touched:
+  - `apps/web/src/features/explore/types.ts`
+  - `apps/web/src/features/explore/mock-data.ts`
+  - `apps/web/src/features/explore/components/ExploreLayout.tsx`
+  - `docs/go-live/fph-execution-log.md`
+- Verification:
+  - `pnpm --filter @freediving.ph/web type-check`
+- Commit hash: recorded in Git history for `fix/fph-go-live`
+- Blockers: none

--- a/docs/go-live/fph-execution-log.md
+++ b/docs/go-live/fph-execution-log.md
@@ -119,3 +119,20 @@
 - Pushed: pending
 - Blockers:
   - shared worktree `apps/web/node_modules` symlink leaks to the original repo, so stock web type-check is not branch-isolated
+
+## 2026-03-31 21:28 Asia/Manila — FRO-195
+
+- Status: completed on shared branch, awaiting push/review
+- Branch: `fix/fph-go-live`
+- Worktree: `/Volumes/Files/softwareengineering/my-projects/freedivingph-go-live`
+- Summary: narrowed restricted group membership to truthful launch scope by removing approval-queue promises from the web UI, limiting group creation to open or invite-only join policies, and replacing fake request-access states with explicit invite-required messaging.
+- Files touched:
+  - `apps/web/src/app/groups/page.tsx`
+  - `apps/web/src/app/groups/[id]/page.tsx`
+  - `docs/go-live/fph-execution-log.md`
+- Verification:
+  - `pnpm exec tsc -p /tmp/fro195-groups-tsconfig.json --noEmit`
+- Commit hash: pending
+- Pushed: pending
+- Blockers:
+  - none for this narrowed launch-scope fix

--- a/docs/go-live/fph-execution-log.md
+++ b/docs/go-live/fph-execution-log.md
@@ -39,7 +39,7 @@
 
 ## 2026-03-31 19:49 Asia/Manila — FRO-190
 
-- Status: completed locally on shared branch, awaiting explicit push/review
+- Status: pushed on shared branch, in review
 - Branch: `fix/fph-go-live`
 - Worktree: `/Volumes/Files/softwareengineering/my-projects/freedivingph-go-live`
 - Summary: removed the fake profile tabs so launch scope only exposes the real profile media grid.
@@ -48,12 +48,13 @@
   - `docs/go-live/fph-execution-log.md`
 - Verification:
   - `pnpm --filter @freediving.ph/web type-check`
-- Commit hash: recorded in Git history for `fix/fph-go-live`
+- Commit hash: `cf904a2`
+- Pushed: yes, on `origin/fix/fph-go-live`
 - Blockers: none
 
 ## 2026-03-31 20:00 Asia/Manila — FRO-194
 
-- Status: completed locally on shared branch, awaiting explicit push/review
+- Status: pushed on shared branch, in review
 - Branch: `fix/fph-go-live`
 - Worktree: `/Volumes/Files/softwareengineering/my-projects/freedivingph-go-live`
 - Summary: aligned Explore site links and share URLs to a dedicated slug helper so the route layer no longer implicitly treats `id` as the public slug contract.
@@ -64,5 +65,28 @@
   - `docs/go-live/fph-execution-log.md`
 - Verification:
   - `pnpm --filter @freediving.ph/web type-check`
+- Commit hash: `495dc1e`
+- Pushed: yes, on `origin/fix/fph-go-live`
+- Blockers: none
+
+## 2026-03-31 20:22 Asia/Manila — FRO-193
+
+- Status: completed on shared branch, awaiting review/merge
+- Branch: `fix/fph-go-live`
+- Worktree: `/Volumes/Files/softwareengineering/my-projects/freedivingph-go-live`
+- Summary: cut the main `/explore` experience over to the real `fphgo` site list contract, removed mock-only rating/tag/review UI from the live path, switched save state to the real backend save endpoints, and added cursor-based loading for the results list.
+- Files touched:
+  - `apps/web/src/features/explore/api/exploreApi.ts`
+  - `apps/web/src/features/explore/components/DiveSpotCard.tsx`
+  - `apps/web/src/features/explore/components/ExploreLayout.tsx`
+  - `apps/web/src/features/explore/components/ExploreMap.tsx`
+  - `apps/web/src/features/explore/components/ExploreResultsPanel.tsx`
+  - `apps/web/src/features/explore/mock-data.ts`
+  - `apps/web/src/features/explore/types.ts`
+  - `docs/go-live/fph-execution-log.md`
+- Verification:
+  - `pnpm --filter @freediving.ph/web type-check`
+  - `rg -n "MOCK_EXPLORE_SPOTS|getMockDiveSpotBySlug" apps/web/src/features/explore/api/exploreApi.ts apps/web/src/features/explore/components/ExploreLayout.tsx 'apps/web/src/app/explore/sites/[slug]/page.tsx' apps/web/src/features/explore/mock-data.ts`
 - Commit hash: recorded in Git history for `fix/fph-go-live`
+- Pushed: pending
 - Blockers: none

--- a/docs/go-live/fph-execution-log.md
+++ b/docs/go-live/fph-execution-log.md
@@ -15,3 +15,24 @@
   - `go test ./internal/app ./internal/features/...`
 - Commit hash: recorded in Git history for `fix/fph-go-live`
 - Blockers: none
+
+## 2026-03-31 19:46 Asia/Manila — FRO-188
+
+- Status: completed on shared branch, awaiting review/merge
+- Branch: `fix/fph-go-live`
+- Worktree: `/Volumes/Files/softwareengineering/my-projects/freedivingph-go-live`
+- Summary: made `/v1/auth/session` the explicit canonical session path in the web client, kept `/v1/me` only as a deprecated alias, and added contract coverage for the alias deprecation headers.
+- Files touched:
+  - `services/fphgo/internal/features/auth/http/handlers.go`
+  - `services/fphgo/internal/app/routes.go`
+  - `services/fphgo/internal/app/routes_contract_test.go`
+  - `apps/web/src/lib/api/fphgo-routes.ts`
+  - `apps/web/src/features/auth/session/use-session.ts`
+  - `apps/web/src/app/profile/page.tsx`
+  - `apps/web/test/fphgo-ci-smoke.test.mjs`
+  - `docs/go-live/fph-execution-log.md`
+- Verification:
+  - `go test ./internal/app ./internal/features/auth/http`
+  - `pnpm --filter @freediving.ph/web type-check`
+- Commit hash: recorded in Git history for `fix/fph-go-live`
+- Blockers: none

--- a/docs/go-live/fph-execution-log.md
+++ b/docs/go-live/fph-execution-log.md
@@ -93,7 +93,7 @@
 
 ## 2026-03-31 21:15 Asia/Manila — FRO-192
 
-- Status: completed on shared branch, awaiting push/review
+- Status: pushed on shared branch, in review
 - Branch: `fix/fph-go-live`
 - Worktree: `/Volumes/Files/softwareengineering/my-projects/freedivingph-go-live`
 - Summary: added real recipient-side request controls to the thread messaging flow, exposed request-action metadata in thread detail, blocked reply UI until a request is accepted, and wired accept/decline endpoints to the live thread category model instead of the legacy conversation request model.
@@ -122,7 +122,7 @@
 
 ## 2026-03-31 21:28 Asia/Manila — FRO-195
 
-- Status: completed on shared branch, awaiting push/review
+- Status: pushed on shared branch, in review
 - Branch: `fix/fph-go-live`
 - Worktree: `/Volumes/Files/softwareengineering/my-projects/freedivingph-go-live`
 - Summary: narrowed restricted group membership to truthful launch scope by removing approval-queue promises from the web UI, limiting group creation to open or invite-only join policies, and replacing fake request-access states with explicit invite-required messaging.
@@ -139,7 +139,7 @@
 
 ## 2026-03-31 21:43 Asia/Manila — FRO-196
 
-- Status: completed on shared branch, awaiting push/review
+- Status: pushed on shared branch, in review
 - Branch: `fix/fph-go-live`
 - Worktree: `/Volumes/Files/softwareengineering/my-projects/freedivingph-go-live`
 - Summary: verified that Chika pseudonymous identity protection is already covered by backend integration tests and exposed the existing report flow in the thread and comment UI so launch now has a basic member report path without changing the privacy model.
@@ -173,7 +173,7 @@
 
 ## 2026-03-31 23:10 Asia/Manila — FRO-199
 
-- Status: completed on shared branch, awaiting review
+- Status: pushed on shared branch, in review
 - Branch: `fix/fph-go-live`
 - Worktree: `/Volumes/Files/softwareengineering/my-projects/freedivingph-go-live`
 - Summary: enforced production media readiness at startup by rejecting incomplete R2/CDN/signing env configuration during config load, and by refusing to boot production if R2 client initialization still fails. This removes the previous launch lie where the API could start successfully and only break when users attempted uploads or URL minting.
@@ -187,14 +187,14 @@
   - `go test ./internal/config`
   - `go test ./internal/app -run TestNope`
   - `go test ./internal/app ./internal/config` still hits the pre-existing `TestRouteSurfaceSnapshot` mismatch in `internal/app`; this ticket did not touch routes
-- Commit hash: pending
-- Pushed: pending
+- Commit hash: `1f78e55`
+- Pushed: yes, on `origin/fix/fph-go-live`
 - Blockers:
   - none for this startup hardening change
 
 ## 2026-03-31 23:20 Asia/Manila — FRO-200
 
-- Status: completed on shared branch, awaiting review
+- Status: pushed on shared branch, in review
 - Branch: `fix/fph-go-live`
 - Worktree: `/Volumes/Files/softwareengineering/my-projects/freedivingph-go-live`
 - Summary: removed `comingSoon` routes from launch-visible navigation so unfinished surfaces are no longer advertised in the sidebar, “more” drawer, or deprecated link exports. The pages may still exist in the repo, but launch navigation no longer pretends they are part of the public product.
@@ -203,14 +203,14 @@
   - `docs/go-live/fph-execution-log.md`
 - Verification:
   - `pnpm exec tsc -p /tmp/fro200-nav-tsconfig.json --noEmit`
-- Commit hash: pending
-- Pushed: pending
+- Commit hash: `e93d88f`
+- Pushed: yes, on `origin/fix/fph-go-live`
 - Blockers:
   - none
 
 ## 2026-03-31 23:35 Asia/Manila — FRO-198
 
-- Status: completed on shared branch, awaiting review
+- Status: pushed on shared branch, in review
 - Branch: `fix/fph-go-live`
 - Worktree: `/Volumes/Files/softwareengineering/my-projects/freedivingph-go-live`
 - Summary: added a repo-backed launch smoke checklist that separates what is already automated from what still requires real deploy-time/manual verification. The checklist is grounded in the current route surface and explicitly calls out that dev-auth smoke is not enough to prove production Clerk or media behavior.
@@ -220,7 +220,24 @@
 - Verification:
   - `rg -n "Automated Smoke Already In Repo|Manual Launch Smoke|Navigation Truth|Known Limits Of This Checklist" docs/go-live/fph-launch-smoke-checklist.md`
   - reviewed `apps/web/test/fphgo-ci-smoke.test.mjs`, `services/fphgo/internal/app/routes.go`, and feature route files to ground checklist steps in current repo truth
+- Commit hash: `1dcc40d`
+- Pushed: yes, on `origin/fix/fph-go-live`
+- Blockers:
+  - real production smoke execution still depends on deploy-time Clerk and media environment; this ticket documents the path and gates instead of faking runtime evidence
+
+## 2026-04-01 03:35 Asia/Manila — FRO-212
+
+- Status: pushed on shared branch, in review
+- Branch: `fix/fph-go-live`
+- Worktree: `/Volumes/Files/softwareengineering/my-projects/freedivingph-go-live`
+- Summary: reconciled the stale execution log with actual git commits, push state, and Linear review state for the completed go-live tickets. This is bookkeeping-only and does not change product behavior.
+- Files touched:
+  - `docs/go-live/fph-execution-log.md`
+- Verification:
+  - `git log --oneline --decorate --graph a7d11d6..HEAD`
+  - `git diff -- docs/go-live/fph-execution-log.md`
+  - verified `FRO-192`, `FRO-195`, `FRO-196`, `FRO-199`, `FRO-200`, and `FRO-198` against Linear `In Review` state and branch truth
 - Commit hash: pending
 - Pushed: pending
 - Blockers:
-  - real production smoke execution still depends on deploy-time Clerk and media environment; this ticket documents the path and gates instead of faking runtime evidence
+  - none

--- a/docs/go-live/fph-execution-log.md
+++ b/docs/go-live/fph-execution-log.md
@@ -115,8 +115,8 @@
   - `go test ./internal/features/messaging/http ./internal/features/messaging/service`
   - `pnpm --filter @freediving.ph/web type-check` still fails in this shared worktree because `apps/web/node_modules` resolves `@freediving.ph/types` back to `/Volumes/Files/softwareengineering/my-projects/freediving.ph/packages/types/src/index.ts` instead of the worktree copy
   - `pnpm exec tsc -p /tmp/fro192-web-tsconfig.json --noEmit` resolves the worktree types correctly; remaining failures are unrelated pre-existing Explore Google Maps typings in `src/app/explore/submit/*` and `src/features/explore/components/ExploreMap.tsx`
-- Commit hash: pending
-- Pushed: pending
+- Commit hash: `04ac4fd`
+- Pushed: yes, on `origin/fix/fph-go-live`
 - Blockers:
   - shared worktree `apps/web/node_modules` symlink leaks to the original repo, so stock web type-check is not branch-isolated
 
@@ -132,8 +132,8 @@
   - `docs/go-live/fph-execution-log.md`
 - Verification:
   - `pnpm exec tsc -p /tmp/fro195-groups-tsconfig.json --noEmit`
-- Commit hash: pending
-- Pushed: pending
+- Commit hash: `aa2b85e`
+- Pushed: yes, on `origin/fix/fph-go-live`
 - Blockers:
   - none for this narrowed launch-scope fix
 
@@ -150,7 +150,44 @@
 - Verification:
   - `pnpm exec tsc -p /tmp/fro196-chika-tsconfig.json --noEmit`
   - reviewed `services/fphgo/internal/features/chika/http/integration_blocks_test.go` to confirm member-vs-moderator real-author behavior and hidden-content behavior are already covered in backend tests
+- Commit hash: `42bd429`
+- Pushed: yes, on `origin/fix/fph-go-live`
+- Blockers:
+  - none for this launch-scope fix
+
+## 2026-03-31 22:05 Asia/Manila — FRO-197
+
+- Status: verified on shared branch, no code change required
+- Branch: `fix/fph-go-live`
+- Worktree: `/Volumes/Files/softwareengineering/my-projects/freedivingph-go-live`
+- Summary: confirmed the feed strategy contract and homepage framing are already stable on the current branch. The backend feed strategy test now passes, and the homepage feed components compile cleanly against the current shared types without needing a new patch.
+- Files touched:
+  - `docs/go-live/fph-execution-log.md`
+- Verification:
+  - `go test ./internal/features/feed/service`
+  - `pnpm exec tsc -p /tmp/fro197-homefeed-tsconfig.json --noEmit`
+- Commit hash: none
+- Pushed: n/a
+- Blockers:
+  - none
+
+## 2026-03-31 23:10 Asia/Manila — FRO-199
+
+- Status: completed on shared branch, awaiting review
+- Branch: `fix/fph-go-live`
+- Worktree: `/Volumes/Files/softwareengineering/my-projects/freedivingph-go-live`
+- Summary: enforced production media readiness at startup by rejecting incomplete R2/CDN/signing env configuration during config load, and by refusing to boot production if R2 client initialization still fails. This removes the previous launch lie where the API could start successfully and only break when users attempted uploads or URL minting.
+- Files touched:
+  - `services/fphgo/internal/config/config.go`
+  - `services/fphgo/internal/config/config_test.go`
+  - `services/fphgo/internal/app/app.go`
+  - `services/fphgo/README.md`
+  - `docs/go-live/fph-execution-log.md`
+- Verification:
+  - `go test ./internal/config`
+  - `go test ./internal/app -run TestNope`
+  - `go test ./internal/app ./internal/config` still hits the pre-existing `TestRouteSurfaceSnapshot` mismatch in `internal/app`; this ticket did not touch routes
 - Commit hash: pending
 - Pushed: pending
 - Blockers:
-  - none for this launch-scope fix
+  - none for this startup hardening change

--- a/docs/go-live/fph-execution-log.md
+++ b/docs/go-live/fph-execution-log.md
@@ -191,3 +191,19 @@
 - Pushed: pending
 - Blockers:
   - none for this startup hardening change
+
+## 2026-03-31 23:20 Asia/Manila — FRO-200
+
+- Status: completed on shared branch, awaiting review
+- Branch: `fix/fph-go-live`
+- Worktree: `/Volumes/Files/softwareengineering/my-projects/freedivingph-go-live`
+- Summary: removed `comingSoon` routes from launch-visible navigation so unfinished surfaces are no longer advertised in the sidebar, “more” drawer, or deprecated link exports. The pages may still exist in the repo, but launch navigation no longer pretends they are part of the public product.
+- Files touched:
+  - `apps/web/src/config/nav.ts`
+  - `docs/go-live/fph-execution-log.md`
+- Verification:
+  - `pnpm exec tsc -p /tmp/fro200-nav-tsconfig.json --noEmit`
+- Commit hash: pending
+- Pushed: pending
+- Blockers:
+  - none

--- a/docs/go-live/fph-execution-log.md
+++ b/docs/go-live/fph-execution-log.md
@@ -88,5 +88,34 @@
   - `pnpm --filter @freediving.ph/web type-check`
   - `rg -n "MOCK_EXPLORE_SPOTS|getMockDiveSpotBySlug" apps/web/src/features/explore/api/exploreApi.ts apps/web/src/features/explore/components/ExploreLayout.tsx 'apps/web/src/app/explore/sites/[slug]/page.tsx' apps/web/src/features/explore/mock-data.ts`
 - Commit hash: recorded in Git history for `fix/fph-go-live`
-- Pushed: pending
+- Pushed: yes, on `origin/fix/fph-go-live`
 - Blockers: none
+
+## 2026-03-31 21:15 Asia/Manila — FRO-192
+
+- Status: completed on shared branch, awaiting push/review
+- Branch: `fix/fph-go-live`
+- Worktree: `/Volumes/Files/softwareengineering/my-projects/freedivingph-go-live`
+- Summary: added real recipient-side request controls to the thread messaging flow, exposed request-action metadata in thread detail, blocked reply UI until a request is accepted, and wired accept/decline endpoints to the live thread category model instead of the legacy conversation request model.
+- Files touched:
+  - `services/fphgo/internal/features/messaging/repo/repo.go`
+  - `services/fphgo/internal/features/messaging/service/service.go`
+  - `services/fphgo/internal/features/messaging/service/service_test.go`
+  - `services/fphgo/internal/features/messaging/http/dto.go`
+  - `services/fphgo/internal/features/messaging/http/routes.go`
+  - `services/fphgo/internal/features/messaging/http/handlers.go`
+  - `services/fphgo/internal/features/messaging/http/integration_test.go`
+  - `apps/web/src/lib/api/fphgo-routes.ts`
+  - `packages/types/src/index.ts`
+  - `apps/web/src/features/messages/api/messages.ts`
+  - `apps/web/src/features/messages/hooks/mutations.ts`
+  - `apps/web/src/features/messages/components/MessagingView.tsx`
+  - `docs/go-live/fph-execution-log.md`
+- Verification:
+  - `go test ./internal/features/messaging/http ./internal/features/messaging/service`
+  - `pnpm --filter @freediving.ph/web type-check` still fails in this shared worktree because `apps/web/node_modules` resolves `@freediving.ph/types` back to `/Volumes/Files/softwareengineering/my-projects/freediving.ph/packages/types/src/index.ts` instead of the worktree copy
+  - `pnpm exec tsc -p /tmp/fro192-web-tsconfig.json --noEmit` resolves the worktree types correctly; remaining failures are unrelated pre-existing Explore Google Maps typings in `src/app/explore/submit/*` and `src/features/explore/components/ExploreMap.tsx`
+- Commit hash: pending
+- Pushed: pending
+- Blockers:
+  - shared worktree `apps/web/node_modules` symlink leaks to the original repo, so stock web type-check is not branch-isolated

--- a/docs/go-live/fph-execution-log.md
+++ b/docs/go-live/fph-execution-log.md
@@ -1,0 +1,17 @@
+# FPH Go-Live Execution Log
+
+## 2026-03-31 19:39 Asia/Manila — FRO-187
+
+- Status: completed on shared branch, awaiting review/merge
+- Branch: `fix/fph-go-live`
+- Worktree: `/Volumes/Files/softwareengineering/my-projects/freedivingph-go-live`
+- Summary: refreshed the `fphgo` route surface snapshot to include the current media routes and aligned stale feed strategy tests with the live presentation copy.
+- Files touched:
+  - `services/fphgo/internal/app/testdata/route_surface.snapshot.json`
+  - `services/fphgo/internal/features/feed/service/strategy_test.go`
+  - `docs/go-live/fph-execution-log.md`
+- Verification:
+  - `go test ./internal/app ./internal/features/feed/service`
+  - `go test ./internal/app ./internal/features/...`
+- Commit hash: recorded in Git history for `fix/fph-go-live`
+- Blockers: none

--- a/docs/go-live/fph-execution-log.md
+++ b/docs/go-live/fph-execution-log.md
@@ -136,3 +136,21 @@
 - Pushed: pending
 - Blockers:
   - none for this narrowed launch-scope fix
+
+## 2026-03-31 21:43 Asia/Manila — FRO-196
+
+- Status: completed on shared branch, awaiting push/review
+- Branch: `fix/fph-go-live`
+- Worktree: `/Volumes/Files/softwareengineering/my-projects/freedivingph-go-live`
+- Summary: verified that Chika pseudonymous identity protection is already covered by backend integration tests and exposed the existing report flow in the thread and comment UI so launch now has a basic member report path without changing the privacy model.
+- Files touched:
+  - `apps/web/src/features/chika/components/ThreadDetail.tsx`
+  - `apps/web/src/app/chika/[id]/page.tsx`
+  - `docs/go-live/fph-execution-log.md`
+- Verification:
+  - `pnpm exec tsc -p /tmp/fro196-chika-tsconfig.json --noEmit`
+  - reviewed `services/fphgo/internal/features/chika/http/integration_blocks_test.go` to confirm member-vs-moderator real-author behavior and hidden-content behavior are already covered in backend tests
+- Commit hash: pending
+- Pushed: pending
+- Blockers:
+  - none for this launch-scope fix

--- a/docs/go-live/fph-launch-smoke-checklist.md
+++ b/docs/go-live/fph-launch-smoke-checklist.md
@@ -1,0 +1,172 @@
+# FPH Launch Smoke Checklist
+
+This is the real go-live smoke path for the current branch.
+
+It is not aspirational. If a check below cannot be executed in the target environment, launch is not ready.
+
+## 1. Preconditions
+
+- API is deployed from `services/fphgo` with production env configured.
+- Web is deployed from `apps/web` and points to the same API base URL.
+- Database migrations are up to date.
+- Clerk production keys are present.
+- Media env is present and valid:
+  - `R2_ACCOUNT_ID`
+  - `R2_ACCESS_KEY_ID`
+  - `R2_SECRET_ACCESS_KEY`
+  - `R2_BUCKET_NAME`
+  - `CDN_BASE_URL`
+  - `MEDIA_SIGNING_SECRET_V1`
+- At least two test member accounts exist for messaging and buddy flows.
+- At least one real dive site exists in the API database.
+
+If any precondition is false, stop calling this a launch check. Fix the environment first.
+
+## 2. Automated Smoke Already In Repo
+
+Existing script:
+- `apps/web/test/fphgo-ci-smoke.test.mjs`
+
+Run:
+
+```bash
+cd apps/web
+FPHGO_BASE_URL=http://localhost:4000 node --test test/fphgo-ci-smoke.test.mjs
+```
+
+What it currently proves:
+- `GET /healthz` responds successfully.
+- `GET /readyz` confirms database readiness.
+- protected routes reject unauthenticated access.
+- `/v1/auth/session` works through the dev-auth smoke harness.
+- `/v1/me` still behaves as the deprecated legacy alias.
+- basic blocks, buddies, chika, messaging, profile, reports, and media read/validation routes respond.
+
+What it does not prove:
+- real Clerk sign-in from web
+- real R2 upload or CDN readback
+- message request accept/decline with two users
+- explore UI behavior in browser
+- groups/events interactive flows in browser
+
+Treat it as a liveness gate, not a launch signoff by itself.
+
+## 3. Manual Launch Smoke
+
+Use the deployed web app and deployed API. Do not run this only against localhost and pretend production is covered.
+
+### A. Platform and Auth
+
+- Open the web homepage and confirm it loads without broken navigation.
+- Sign in through Clerk from the real web app.
+- Confirm the signed-in session resolves current user identity.
+- Open your profile via `/{username}` and confirm the route resolves correctly.
+- Confirm old `/profile` path still redirects instead of becoming the canonical surface again.
+
+Block launch if:
+- sign-in fails
+- signed-in session does not hydrate
+- `/{username}` route fails or loops
+
+### B. Media and Profile
+
+- Upload a profile avatar from the web app.
+- Confirm the avatar persists after refresh.
+- Publish at least one profile media post.
+- Confirm the profile media grid loads the new item.
+- Open the media item and confirm the rendered URL is served from the configured media delivery path.
+
+Block launch if:
+- upload fails
+- upload succeeds but the asset does not read back
+- minted media URLs fail
+- profile media appears only locally and disappears after refresh
+
+### C. Messaging
+
+- From account A, start a first-time conversation with account B through a real product entry point.
+- On account B, open Messages and confirm the thread is visibly still a request.
+- Accept the request from account B.
+- Confirm the thread moves into normal messaging behavior and replies work both ways.
+- Repeat with a fresh request and decline it.
+- Confirm the declined thread is resolved honestly and cannot be treated as an active chat without reopening through the supported flow.
+
+Block launch if:
+- request-state is invisible
+- recipient cannot accept or decline
+- accepted threads do not become normal chats
+- decline leaves a misleading active thread state
+
+### D. Explore and Buddy Flows
+
+- Open `/explore` and confirm cards come from real API data, not mock placeholders.
+- Open at least one site detail page and confirm slug-based navigation resolves correctly.
+- Confirm explore list pagination continues using real API data.
+- Save and unsave a site while signed in.
+- On a site detail page, verify buddy preview renders and is tied to the real site.
+
+Block launch if:
+- explore still depends on mock-only data in the live path
+- site detail routing breaks on slug
+- save/unsave silently fails
+
+### E. Buddy Finder and Buddies
+
+- Create a buddy intent while signed in.
+- Confirm it appears in your own intents list.
+- Confirm browse or preview surfaces still render without exposing blocked or invalid states.
+- Use the message/contact path from a buddy surface and verify it lands in the real messaging flow.
+
+Block launch if:
+- intents cannot be created or read back
+- site-linked flows fall apart into area-only ambiguity when a site is present
+- contact path dead-ends
+
+### F. Groups and Events
+
+- Open `/groups` and confirm open groups can still be joined.
+- Confirm approval-based groups are not pretending an approval queue exists; the UI should state invite-required launch behavior instead.
+- Open `/events`, create or join a launch-valid event, and confirm detail and attendee behavior remain consistent.
+
+Block launch if:
+- groups still advertise approval workflows that do not exist
+- open join is broken
+- events list/detail/join are inconsistent
+
+### G. Chika and Basic Moderation
+
+- Open `/chika`, list categories, and open a real thread.
+- In a pseudonymous category, confirm author identity is not exposed like a normal member profile.
+- Confirm report actions exist on thread and comment surfaces.
+
+Block launch if:
+- pseudonymous author identity leaks to normal members
+- report path is missing from live UI
+
+### H. Navigation Truth
+
+- Confirm launch nav does not advertise Competitive Records, Training Logs, Safety, Awareness, Services, Media, Marketplace, or Collaboration as live product areas.
+- Confirm the current nav only exposes launch-supported surfaces.
+
+Block launch if:
+- fake or coming-soon routes are visible in launch nav
+
+## 4. Required Launch Outcome
+
+Launch is only green when:
+- automated smoke passes
+- manual smoke passes for auth, profile media, messaging, explore, buddy flows, groups/events, and chika
+- any blocked checks are explicitly resolved, not hand-waved
+
+Launch is blocked when:
+- production media env is missing or invalid
+- Clerk sign-in is not proven end to end
+- any core user-visible flow above is broken, fake, or unresolved
+
+## 5. Known Limits Of This Checklist
+
+- The current automated smoke script relies on the dev-auth harness using `X-User-ID`. That is useful for API smoke, but it is not sufficient proof of real production Clerk behavior.
+- Real media verification still requires a target environment with working R2/CDN config.
+- Two-account messaging and buddy verification cannot be faked with a single-user smoke run.
+
+If someone wants to declare go-live readiness without these checks, they are guessing.

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -581,6 +581,8 @@ export interface MessagingThreadDetailResponse {
   createdAt: string;
   lastReadMessageId?: string;
   canSend: boolean;
+  activeRequest: boolean;
+  canResolveRequest: boolean;
 }
 
 export interface MessagingThreadMessagesResponse {
@@ -618,6 +620,12 @@ export interface MessagingUpdateThreadCategoryResponse {
   threadId: string;
   category: "primary" | "transactions";
   updated: boolean;
+}
+
+export interface MessagingResolveThreadRequestResponse {
+  threadId: string;
+  action: "accepted" | "declined";
+  resolved: boolean;
 }
 
 export type MessagingRealtimeEnvelope<T = unknown> = {

--- a/services/fphgo/README.md
+++ b/services/fphgo/README.md
@@ -43,11 +43,20 @@ await fetch("/v1/messages/threads?category=primary", {
 - `CLERK_JWT_AUDIENCE` (optional, CSV list, requires token `aud` overlap)
 - `DEV_AUTH` (optional, local dev fallback only)
 - `API_BASE_URL` (optional, public API origin metadata)
+- `R2_ACCOUNT_ID` (required in production; Cloudflare R2 account id)
+- `R2_ACCESS_KEY_ID` (required in production)
+- `R2_SECRET_ACCESS_KEY` (required in production)
+- `R2_BUCKET_NAME` (required in production)
+- `R2_REGION` (optional; defaults to `auto`)
+- `CDN_BASE_URL` (required in production; public media delivery base URL)
+- `MEDIA_SIGNING_SECRET_V1` (required in production; HMAC signing secret for media URLs)
+- `MEDIA_SIGNING_KEY_VERSION` (optional, default `1`)
 - `CHIKA_PSEUDONYM_SECRET` (required in production; HMAC secret for pseudonymous alias generation)
 
 Production guards:
 - `APP_ENV=production` rejects `DEV_AUTH=true`.
 - `APP_ENV=production` rejects wildcard `CORS_ORIGINS=*`.
+- `APP_ENV=production` requires the R2 upload envs plus `CDN_BASE_URL` and `MEDIA_SIGNING_SECRET_V1`.
 - `APP_ENV=production` requires `CHIKA_PSEUDONYM_SECRET`.
 
 ## Example curl

--- a/services/fphgo/internal/app/app.go
+++ b/services/fphgo/internal/app/app.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"log/slog"
+	"strings"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -217,6 +218,10 @@ func BuildDependencies(cfg config.Config, logger *slog.Logger, pool *pgxpool.Poo
 		Region:          cfg.R2Region,
 	})
 	if err != nil {
+		if strings.EqualFold(cfg.Env, "production") {
+			logger.Error("media r2 storage init failed", "error", err)
+			panic(err)
+		}
 		logger.Warn("media r2 storage disabled", "error", err)
 	}
 	mediaService := mediaservice.New(

--- a/services/fphgo/internal/app/routes.go
+++ b/services/fphgo/internal/app/routes.go
@@ -179,7 +179,7 @@ func NewRouterWithBuildInfo(cfg config.Config, deps *Dependencies, logger *slog.
 				member.Mount("/v1/auth", authRouter)
 			}
 			if deps.AuthHandler != nil {
-				member.Get("/v1/me", deps.AuthHandler.GetSession)
+				member.Get("/v1/me", deps.AuthHandler.GetLegacySession)
 			}
 			member.Group(func(messages chi.Router) {
 				messages.Use(middleware.RequirePermission(authz.PermissionMessagingRead))

--- a/services/fphgo/internal/app/routes_contract_test.go
+++ b/services/fphgo/internal/app/routes_contract_test.go
@@ -135,6 +135,12 @@ func TestV1CoreEndpointContracts(t *testing.T) {
 		assertStringField(t, payload, "globalRole")
 		assertStringField(t, payload, "accountStatus")
 		assertArrayField(t, payload, "permissions")
+		if got := rec.Header().Get("Deprecation"); got != "true" {
+			t.Fatalf("expected legacy /v1/me deprecation header, got %q", got)
+		}
+		if got := rec.Header().Get("Link"); got != `</v1/auth/session>; rel="successor-version"` {
+			t.Fatalf("expected canonical session link header, got %q", got)
+		}
 	})
 
 	t.Run("GET /v1/messages/threads", func(t *testing.T) {

--- a/services/fphgo/internal/app/testdata/route_surface.snapshot.json
+++ b/services/fphgo/internal/app/testdata/route_surface.snapshot.json
@@ -230,7 +230,15 @@
     },
     {
       "method": "GET",
+      "pattern": "/v1/media/by-username/{username}"
+    },
+    {
+      "method": "GET",
       "pattern": "/v1/media/mine"
+    },
+    {
+      "method": "POST",
+      "pattern": "/v1/media/posts"
     },
     {
       "method": "POST",

--- a/services/fphgo/internal/config/config.go
+++ b/services/fphgo/internal/config/config.go
@@ -126,6 +126,24 @@ func Load() (Config, error) {
 		if chikaPseudonymSecret == "" {
 			return Config{}, fmt.Errorf("CHIKA_PSEUDONYM_SECRET is required in production")
 		}
+		if r2AccountID == "" {
+			return Config{}, fmt.Errorf("R2_ACCOUNT_ID is required in production")
+		}
+		if r2AccessKeyID == "" {
+			return Config{}, fmt.Errorf("R2_ACCESS_KEY_ID is required in production")
+		}
+		if r2SecretAccessKey == "" {
+			return Config{}, fmt.Errorf("R2_SECRET_ACCESS_KEY is required in production")
+		}
+		if r2BucketName == "" {
+			return Config{}, fmt.Errorf("R2_BUCKET_NAME is required in production")
+		}
+		if mediaCDNBaseURL == "" {
+			return Config{}, fmt.Errorf("CDN_BASE_URL is required in production")
+		}
+		if mediaSigningSecretV1 == "" {
+			return Config{}, fmt.Errorf("MEDIA_SIGNING_SECRET_V1 is required in production")
+		}
 	}
 	if clerkSecretKey == "" && !devAuth {
 		return Config{}, fmt.Errorf("CLERK_SECRET_KEY is required unless DEV_AUTH=true")

--- a/services/fphgo/internal/config/config_test.go
+++ b/services/fphgo/internal/config/config_test.go
@@ -69,6 +69,12 @@ func TestLoadReadsRenderCompatEnv(t *testing.T) {
 	t.Setenv("CORS_ORIGIN", "https://app.example.com")
 	t.Setenv("API_URL", "https://api.example.com")
 	t.Setenv("CHIKA_PSEUDONYM_SECRET", "secret")
+	t.Setenv("R2_ACCOUNT_ID", "account")
+	t.Setenv("R2_ACCESS_KEY_ID", "access")
+	t.Setenv("R2_SECRET_ACCESS_KEY", "secret-key")
+	t.Setenv("R2_BUCKET_NAME", "bucket")
+	t.Setenv("CDN_BASE_URL", "https://cdn.example.com")
+	t.Setenv("MEDIA_SIGNING_SECRET_V1", "signing-secret")
 
 	cfg, err := Load()
 	if err != nil {
@@ -95,5 +101,43 @@ func TestLoadRejectsMissingChikaPseudonymSecretInProduction(t *testing.T) {
 	_, err := Load()
 	if err == nil || err.Error() != "CHIKA_PSEUDONYM_SECRET is required in production" {
 		t.Fatalf("expected missing CHIKA_PSEUDONYM_SECRET error, got %v", err)
+	}
+}
+
+func TestLoadRejectsMissingMediaConfigInProduction(t *testing.T) {
+	t.Setenv("DB_DSN", "postgres://example")
+	t.Setenv("APP_ENV", "production")
+	t.Setenv("CLERK_SECRET_KEY", "sk_test")
+	t.Setenv("CORS_ORIGINS", "https://app.example.com")
+	t.Setenv("CHIKA_PSEUDONYM_SECRET", "secret")
+
+	_, err := Load()
+	if err == nil || err.Error() != "R2_ACCOUNT_ID is required in production" {
+		t.Fatalf("expected missing R2_ACCOUNT_ID error, got %v", err)
+	}
+}
+
+func TestLoadAcceptsProductionMediaConfig(t *testing.T) {
+	t.Setenv("DB_DSN", "postgres://example")
+	t.Setenv("APP_ENV", "production")
+	t.Setenv("CLERK_SECRET_KEY", "sk_test")
+	t.Setenv("CORS_ORIGINS", "https://app.example.com")
+	t.Setenv("CHIKA_PSEUDONYM_SECRET", "secret")
+	t.Setenv("R2_ACCOUNT_ID", "account")
+	t.Setenv("R2_ACCESS_KEY_ID", "access")
+	t.Setenv("R2_SECRET_ACCESS_KEY", "secret-key")
+	t.Setenv("R2_BUCKET_NAME", "bucket")
+	t.Setenv("CDN_BASE_URL", "https://cdn.example.com")
+	t.Setenv("MEDIA_SIGNING_SECRET_V1", "signing-secret")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("expected production media config to load, got %v", err)
+	}
+	if cfg.R2BucketName != "bucket" {
+		t.Fatalf("expected bucket to load, got %s", cfg.R2BucketName)
+	}
+	if cfg.MediaCDNBaseURL != "https://cdn.example.com" {
+		t.Fatalf("expected CDN base URL to load, got %s", cfg.MediaCDNBaseURL)
 	}
 }

--- a/services/fphgo/internal/features/auth/http/handlers.go
+++ b/services/fphgo/internal/features/auth/http/handlers.go
@@ -16,6 +16,17 @@ func New() *Handlers {
 }
 
 func (h *Handlers) GetSession(w http.ResponseWriter, r *http.Request) {
+	h.writeSession(w, r)
+}
+
+func (h *Handlers) GetLegacySession(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Deprecation", "true")
+	w.Header().Set("Sunset", "Tue, 30 Jun 2026 00:00:00 GMT")
+	w.Header().Set("Link", `</v1/auth/session>; rel="successor-version"`)
+	h.writeSession(w, r)
+}
+
+func (h *Handlers) writeSession(w http.ResponseWriter, r *http.Request) {
 	identity, ok := middleware.CurrentIdentity(r.Context())
 	if !ok || !identity.IsAuthenticated() {
 		httpx.JSON(w, http.StatusUnauthorized, map[string]any{

--- a/services/fphgo/internal/features/feed/service/strategy_test.go
+++ b/services/fphgo/internal/features/feed/service/strategy_test.go
@@ -10,7 +10,7 @@ func TestPresentationForBuddySignalInNearbyMode(t *testing.T) {
 	if got.TypeLabel != "Buddy call" {
 		t.Fatalf("expected buddy label, got %q", got.TypeLabel)
 	}
-	if got.RankLabel != "Actionable now" {
+	if got.RankLabel != "Buddy check" {
 		t.Fatalf("expected actionable rank label, got %q", got.RankLabel)
 	}
 	if got.Tone != "coordination" {
@@ -26,7 +26,7 @@ func TestContextForMode(t *testing.T) {
 	if got.Greeting == "" || got.Message == "" || got.SafetyBadge == "" {
 		t.Fatalf("expected non-empty mode frame, got %#v", got)
 	}
-	if got.Greeting != "Training is the discipline lane" {
+	if got.Greeting != "Training & Progress" {
 		t.Fatalf("unexpected training greeting %q", got.Greeting)
 	}
 }

--- a/services/fphgo/internal/features/messaging/http/dto.go
+++ b/services/fphgo/internal/features/messaging/http/dto.go
@@ -137,6 +137,8 @@ type ThreadDetailResponse struct {
 	CreatedAt         string                  `json:"createdAt"`
 	LastReadMessageID string                  `json:"lastReadMessageId,omitempty"`
 	CanSend           bool                    `json:"canSend"`
+	ActiveRequest     bool                    `json:"activeRequest"`
+	CanResolveRequest bool                    `json:"canResolveRequest"`
 }
 
 type ListThreadMessagesResponse struct {
@@ -170,4 +172,10 @@ type UpdateThreadCategoryResponse struct {
 	ThreadID string `json:"threadId"`
 	Category string `json:"category"`
 	Updated  bool   `json:"updated"`
+}
+
+type ResolveThreadRequestResponse struct {
+	ThreadID string `json:"threadId"`
+	Action   string `json:"action"`
+	Resolved bool   `json:"resolved"`
 }

--- a/services/fphgo/internal/features/messaging/http/handlers.go
+++ b/services/fphgo/internal/features/messaging/http/handlers.go
@@ -420,6 +420,39 @@ func (h *Handlers) GetThread(w http.ResponseWriter, r *http.Request) {
 	httpx.JSON(w, http.StatusOK, mapThreadDetail(result, actorID))
 }
 
+func (h *Handlers) AcceptThreadRequest(w http.ResponseWriter, r *http.Request) {
+	h.resolveThreadRequest(w, r, true)
+}
+
+func (h *Handlers) DeclineThreadRequest(w http.ResponseWriter, r *http.Request) {
+	h.resolveThreadRequest(w, r, false)
+}
+
+func (h *Handlers) resolveThreadRequest(w http.ResponseWriter, r *http.Request, accept bool) {
+	actorID, err := h.requireLocalActorID(r)
+	if err != nil {
+		httpx.Error(w, middleware.RequestIDFromContext(r.Context()), err)
+		return
+	}
+	threadID, issues, ok := httpx.ParseUUIDParam(chi.URLParam(r, "threadId"), "threadId")
+	if !ok {
+		httpx.WriteValidationError(w, issues)
+		return
+	}
+
+	var result messagingservice.ResolveThreadRequestResult
+	if accept {
+		result, err = h.service.AcceptThreadRequest(r.Context(), actorID, threadID, middleware.RequestIDFromContext(r.Context()))
+	} else {
+		result, err = h.service.DeclineThreadRequest(r.Context(), actorID, threadID, middleware.RequestIDFromContext(r.Context()))
+	}
+	if err != nil {
+		httpx.Error(w, middleware.RequestIDFromContext(r.Context()), err)
+		return
+	}
+	httpx.JSON(w, http.StatusOK, ResolveThreadRequestResponse(result))
+}
+
 func (h *Handlers) ListThreadMessages(w http.ResponseWriter, r *http.Request) {
 	actorID, err := h.requireLocalActorID(r)
 	if err != nil {
@@ -579,6 +612,8 @@ func mapThreadDetail(result messagingservice.ThreadDetailResult, actorID string)
 		CreatedAt:         result.Thread.CreatedAt.Format(time.RFC3339),
 		LastReadMessageID: lastReadMessageID,
 		CanSend:           result.CanSend,
+		ActiveRequest:     result.ActiveRequest,
+		CanResolveRequest: result.CanResolveRequest,
 	}
 }
 

--- a/services/fphgo/internal/features/messaging/http/integration_test.go
+++ b/services/fphgo/internal/features/messaging/http/integration_test.go
@@ -232,6 +232,26 @@ func (m *memoryMessagingRepo) UpdateThreadCategory(_ context.Context, threadID s
 	return nil
 }
 
+func (m *memoryMessagingRepo) PromoteThreadRequestToPrimary(_ context.Context, threadID, userID string) error {
+	threadMembers, ok := m.members[threadID]
+	if !ok {
+		return nil
+	}
+	if _, exists := threadMembers[userID]; exists {
+		threadMembers[userID] = messagingrepo.ThreadCategoryPrimary
+	}
+	return nil
+}
+
+func (m *memoryMessagingRepo) ArchiveThreadForUser(_ context.Context, threadID, userID string) error {
+	threadMembers, ok := m.members[threadID]
+	if !ok {
+		return nil
+	}
+	delete(threadMembers, userID)
+	return nil
+}
+
 type messagingNoRows struct{}
 
 func (messagingNoRows) Error() string { return "no rows" }

--- a/services/fphgo/internal/features/messaging/http/routes.go
+++ b/services/fphgo/internal/features/messaging/http/routes.go
@@ -20,6 +20,8 @@ func Routes(h *Handlers) chi.Router {
 	r.Group(func(write chi.Router) {
 		write.Use(middleware.RequirePermission(authz.PermissionMessagingWrite))
 		write.Post("/threads/direct", h.OpenDirectThread)
+		write.Post("/threads/{threadId}/accept", h.AcceptThreadRequest)
+		write.Post("/threads/{threadId}/decline", h.DeclineThreadRequest)
 		write.Post("/threads/{threadId}/messages", h.SendThreadMessage)
 		write.Post("/threads/{threadId}/read", h.MarkThreadRead)
 		write.Post("/threads/{threadId}/category", h.UpdateThreadCategory)

--- a/services/fphgo/internal/features/messaging/repo/repo.go
+++ b/services/fphgo/internal/features/messaging/repo/repo.go
@@ -435,18 +435,10 @@ func (r *Repo) OpenOrCreateDirectThread(ctx context.Context, actorID, targetUser
 		}
 	}
 
-	if err := r.queries.UpsertThreadMember(ctx, messagingqlc.UpsertThreadMemberParams{
-		ThreadID:      toUUID(threadID),
-		UserID:        toUUID(actorID),
-		InboxCategory: string(ThreadCategoryPrimary),
-	}); err != nil {
+	if err := r.upsertThreadMember(ctx, threadID, actorID, ThreadCategoryPrimary); err != nil {
 		return Thread{}, err
 	}
-	if err := r.queries.UpsertThreadMember(ctx, messagingqlc.UpsertThreadMemberParams{
-		ThreadID:      toUUID(threadID),
-		UserID:        toUUID(targetUserID),
-		InboxCategory: string(targetCategory),
-	}); err != nil {
+	if err := r.upsertThreadMember(ctx, threadID, targetUserID, targetCategory); err != nil {
 		return Thread{}, err
 	}
 
@@ -673,6 +665,17 @@ func (r *Repo) PromoteThreadRequestToPrimary(ctx context.Context, threadID, user
 	return err
 }
 
+func (r *Repo) ArchiveThreadForUser(ctx context.Context, threadID, userID string) error {
+	_, err := r.pool.Exec(ctx, `
+		UPDATE message_thread_members
+		SET is_archived = TRUE
+		WHERE thread_id = $1
+		  AND user_id = $2
+		  AND left_at IS NULL
+	`, toUUID(threadID), toUUID(userID))
+	return err
+}
+
 func (r *Repo) UpdateThreadCategory(ctx context.Context, threadID string, category ThreadCategory) error {
 	_, err := r.pool.Exec(ctx, `
 		UPDATE message_thread_members
@@ -680,6 +683,28 @@ func (r *Repo) UpdateThreadCategory(ctx context.Context, threadID string, catego
 		WHERE thread_id = $1
 		  AND left_at IS NULL
 	`, toUUID(threadID), string(category))
+	return err
+}
+
+func (r *Repo) upsertThreadMember(ctx context.Context, threadID, userID string, category ThreadCategory) error {
+	_, err := r.pool.Exec(ctx, `
+		INSERT INTO message_thread_members (
+		  thread_id,
+		  user_id,
+		  inbox_category,
+		  joined_at,
+		  left_at,
+		  is_archived,
+		  is_muted
+		)
+		VALUES ($1, $2, $3::message_inbox_category, NOW(), NULL, FALSE, FALSE)
+		ON CONFLICT (thread_id, user_id)
+		DO UPDATE SET
+		  inbox_category = EXCLUDED.inbox_category,
+		  joined_at = COALESCE(message_thread_members.joined_at, NOW()),
+		  left_at = NULL,
+		  is_archived = FALSE
+	`, toUUID(threadID), toUUID(userID), string(category))
 	return err
 }
 

--- a/services/fphgo/internal/features/messaging/service/service.go
+++ b/services/fphgo/internal/features/messaging/service/service.go
@@ -138,9 +138,11 @@ type ThreadListResult struct {
 }
 
 type ThreadDetailResult struct {
-	Thread       messagingrepo.Thread
-	Participants []messagingrepo.ThreadParticipant
-	CanSend      bool
+	Thread            messagingrepo.Thread
+	Participants      []messagingrepo.ThreadParticipant
+	CanSend           bool
+	ActiveRequest     bool
+	CanResolveRequest bool
 }
 
 type ThreadMessagesInput struct {
@@ -180,6 +182,12 @@ type UpdateThreadCategoryInput struct {
 	ThreadID  string
 	Category  string
 	RequestID string
+}
+
+type ResolveThreadRequestResult struct {
+	ThreadID string
+	Action   string
+	Resolved bool
 }
 
 func New(repo messagingRepository, hub messageBroadcaster, blockService blockChecker, opts ...Option) *Service {
@@ -581,7 +589,9 @@ type threadRepository interface {
 	GetThreadMessage(ctx context.Context, threadID string, messageID int64) (messagingrepo.ThreadMessage, error)
 	ThreadMemberIDs(ctx context.Context, threadID string) ([]string, error)
 	IsThreadMember(ctx context.Context, threadID, userID string) (bool, error)
+	PromoteThreadRequestToPrimary(ctx context.Context, threadID, userID string) error
 	UpdateThreadCategory(ctx context.Context, threadID string, category messagingrepo.ThreadCategory) error
+	ArchiveThreadForUser(ctx context.Context, threadID, userID string) error
 }
 
 type targetedBroadcaster interface {
@@ -712,10 +722,74 @@ func (s *Service) GetThreadDetail(ctx context.Context, actorID, threadID string)
 		return ThreadDetailResult{}, apperrors.New(http.StatusInternalServerError, "thread_detail_failed", "failed to load participants", err)
 	}
 	return ThreadDetailResult{
-		Thread:       thread,
-		Participants: participants,
-		CanSend:      true,
+		Thread:            thread,
+		Participants:      participants,
+		CanSend:           thread.Category != messagingrepo.ThreadCategoryRequests,
+		ActiveRequest:     thread.Category == messagingrepo.ThreadCategoryRequests,
+		CanResolveRequest: thread.Category == messagingrepo.ThreadCategoryRequests,
 	}, nil
+}
+
+func (s *Service) AcceptThreadRequest(ctx context.Context, actorID, threadID, requestID string) (ResolveThreadRequestResult, error) {
+	repo, err := s.threadRepo()
+	if err != nil {
+		return ResolveThreadRequestResult{}, err
+	}
+	member, err := repo.IsThreadMember(ctx, threadID, actorID)
+	if err != nil {
+		return ResolveThreadRequestResult{}, apperrors.New(http.StatusInternalServerError, "thread_member_check_failed", "failed to validate membership", err)
+	}
+	if !member {
+		return ResolveThreadRequestResult{}, apperrors.New(http.StatusForbidden, "forbidden", "not a thread member", nil)
+	}
+	thread, err := repo.GetThread(ctx, threadID, actorID)
+	if err != nil {
+		if messagingrepo.IsNoRows(err) {
+			return ResolveThreadRequestResult{}, apperrors.New(http.StatusNotFound, "thread_not_found", "thread not found", err)
+		}
+		return ResolveThreadRequestResult{}, apperrors.New(http.StatusInternalServerError, "thread_detail_failed", "failed to load thread", err)
+	}
+	if thread.Category != messagingrepo.ThreadCategoryRequests {
+		return ResolveThreadRequestResult{}, apperrors.New(http.StatusConflict, "invalid_state", "thread request is not pending", nil)
+	}
+	if err := repo.PromoteThreadRequestToPrimary(ctx, threadID, actorID); err != nil {
+		return ResolveThreadRequestResult{}, apperrors.New(http.StatusInternalServerError, "thread_category_update_failed", "failed to accept thread request", err)
+	}
+	if memberIDs, memberErr := repo.ThreadMemberIDs(ctx, threadID); memberErr == nil {
+		s.broadcastThreadEnvelope(memberIDs, requestID, "thread.updated", map[string]any{"threadId": threadID})
+	}
+	return ResolveThreadRequestResult{ThreadID: threadID, Action: "accepted", Resolved: true}, nil
+}
+
+func (s *Service) DeclineThreadRequest(ctx context.Context, actorID, threadID, requestID string) (ResolveThreadRequestResult, error) {
+	repo, err := s.threadRepo()
+	if err != nil {
+		return ResolveThreadRequestResult{}, err
+	}
+	member, err := repo.IsThreadMember(ctx, threadID, actorID)
+	if err != nil {
+		return ResolveThreadRequestResult{}, apperrors.New(http.StatusInternalServerError, "thread_member_check_failed", "failed to validate membership", err)
+	}
+	if !member {
+		return ResolveThreadRequestResult{}, apperrors.New(http.StatusForbidden, "forbidden", "not a thread member", nil)
+	}
+	thread, err := repo.GetThread(ctx, threadID, actorID)
+	if err != nil {
+		if messagingrepo.IsNoRows(err) {
+			return ResolveThreadRequestResult{}, apperrors.New(http.StatusNotFound, "thread_not_found", "thread not found", err)
+		}
+		return ResolveThreadRequestResult{}, apperrors.New(http.StatusInternalServerError, "thread_detail_failed", "failed to load thread", err)
+	}
+	if thread.Category != messagingrepo.ThreadCategoryRequests {
+		return ResolveThreadRequestResult{}, apperrors.New(http.StatusConflict, "invalid_state", "thread request is not pending", nil)
+	}
+	if err := repo.ArchiveThreadForUser(ctx, threadID, actorID); err != nil {
+		return ResolveThreadRequestResult{}, apperrors.New(http.StatusInternalServerError, "thread_request_decline_failed", "failed to decline thread request", err)
+	}
+	if memberIDs, memberErr := repo.ThreadMemberIDs(ctx, threadID); memberErr == nil {
+		s.broadcastThreadEnvelope(memberIDs, requestID, "thread.updated", map[string]any{"threadId": threadID})
+	}
+	return ResolveThreadRequestResult{ThreadID: threadID, Action: "declined", Resolved: true}, nil
 }
 
 func (s *Service) ListThreadMessages(ctx context.Context, input ThreadMessagesInput) (ThreadMessagesResult, error) {

--- a/services/fphgo/internal/features/messaging/service/service_test.go
+++ b/services/fphgo/internal/features/messaging/service/service_test.go
@@ -135,3 +135,128 @@ func TestSendConversationMessageRejectsInvalidMetadata(t *testing.T) {
 		t.Fatal("expected metadata validation error")
 	}
 }
+
+func TestGetThreadDetailRequestDisablesComposer(t *testing.T) {
+	repo := newThreadRepoStub(messagingrepo.ThreadCategoryRequests)
+	svc := New(repo, hubStub{}, blockCheckerStub{})
+
+	result, err := svc.GetThreadDetail(context.Background(), repo.actorID, repo.thread.ID)
+	if err != nil {
+		t.Fatalf("expected thread detail, got error: %v", err)
+	}
+	if result.CanSend {
+		t.Fatal("expected request thread to disable sending until accepted")
+	}
+	if !result.ActiveRequest || !result.CanResolveRequest {
+		t.Fatal("expected request thread to be actionable for the recipient")
+	}
+}
+
+func TestDeclineThreadRequestArchivesRecipientMembership(t *testing.T) {
+	repo := newThreadRepoStub(messagingrepo.ThreadCategoryRequests)
+	svc := New(repo, hubStub{}, blockCheckerStub{})
+
+	result, err := svc.DeclineThreadRequest(context.Background(), repo.actorID, repo.thread.ID, "")
+	if err != nil {
+		t.Fatalf("expected decline to succeed, got error: %v", err)
+	}
+	if !result.Resolved || result.Action != "declined" {
+		t.Fatalf("unexpected decline result: %#v", result)
+	}
+	if !repo.archived {
+		t.Fatal("expected recipient membership to be archived")
+	}
+}
+
+func TestAcceptThreadRequestPromotesRecipientToPrimary(t *testing.T) {
+	repo := newThreadRepoStub(messagingrepo.ThreadCategoryRequests)
+	svc := New(repo, hubStub{}, blockCheckerStub{})
+
+	result, err := svc.AcceptThreadRequest(context.Background(), repo.actorID, repo.thread.ID, "")
+	if err != nil {
+		t.Fatalf("expected accept to succeed, got error: %v", err)
+	}
+	if !result.Resolved || result.Action != "accepted" {
+		t.Fatalf("unexpected accept result: %#v", result)
+	}
+	if repo.thread.Category != messagingrepo.ThreadCategoryPrimary {
+		t.Fatalf("expected recipient thread category to be primary, got %s", repo.thread.Category)
+	}
+}
+
+type threadRepoStub struct {
+	repoStub
+	thread   messagingrepo.Thread
+	actorID  string
+	archived bool
+}
+
+func newThreadRepoStub(category messagingrepo.ThreadCategory) *threadRepoStub {
+	now := time.Now().UTC()
+	return &threadRepoStub{
+		thread: messagingrepo.Thread{
+			ID:            "550e8400-e29b-41d4-a716-446655440099",
+			Type:          messagingrepo.ThreadKindDirect,
+			Category:      category,
+			CreatedAt:     now,
+			LastMessageAt: now,
+		},
+		actorID: "550e8400-e29b-41d4-a716-446655440000",
+	}
+}
+
+func (s *threadRepoStub) OpenOrCreateDirectThread(context.Context, string, string, messagingrepo.ThreadCategory) (messagingrepo.Thread, error) {
+	return s.thread, nil
+}
+func (s *threadRepoStub) AreUsersBuddies(context.Context, string, string) (bool, error) {
+	return false, nil
+}
+func (s *threadRepoStub) ListThreads(context.Context, messagingrepo.ListThreadsInput) ([]messagingrepo.ThreadSummary, error) {
+	return nil, nil
+}
+func (s *threadRepoStub) GetThread(_ context.Context, threadID, userID string) (messagingrepo.Thread, error) {
+	if threadID != s.thread.ID || userID != s.actorID {
+		return messagingrepo.Thread{}, errors.New("missing")
+	}
+	return s.thread, nil
+}
+func (s *threadRepoStub) ListThreadParticipants(context.Context, string) ([]messagingrepo.ThreadParticipant, error) {
+	return []messagingrepo.ThreadParticipant{{UserID: s.actorID}, {UserID: "550e8400-e29b-41d4-a716-446655440001"}}, nil
+}
+func (s *threadRepoStub) ListThreadMessages(context.Context, messagingrepo.ListThreadMessagesInput) ([]messagingrepo.ThreadMessage, error) {
+	return nil, nil
+}
+func (s *threadRepoStub) CreateThreadMessage(context.Context, string, string, string, *string) (messagingrepo.ThreadMessage, error) {
+	return messagingrepo.ThreadMessage{}, nil
+}
+func (s *threadRepoStub) MarkThreadRead(context.Context, string, string, int64) error { return nil }
+func (s *threadRepoStub) GetThreadMessage(context.Context, string, int64) (messagingrepo.ThreadMessage, error) {
+	return messagingrepo.ThreadMessage{}, nil
+}
+func (s *threadRepoStub) ThreadMemberIDs(context.Context, string) ([]string, error) {
+	return []string{s.actorID, "550e8400-e29b-41d4-a716-446655440001"}, nil
+}
+func (s *threadRepoStub) IsThreadMember(_ context.Context, threadID, userID string) (bool, error) {
+	return threadID == s.thread.ID && userID == s.actorID, nil
+}
+func (s *threadRepoStub) UpdateThreadCategory(_ context.Context, threadID string, category messagingrepo.ThreadCategory) error {
+	if threadID != s.thread.ID {
+		return errors.New("missing")
+	}
+	s.thread.Category = category
+	return nil
+}
+func (s *threadRepoStub) PromoteThreadRequestToPrimary(_ context.Context, threadID, userID string) error {
+	if threadID != s.thread.ID || userID != s.actorID {
+		return errors.New("missing")
+	}
+	s.thread.Category = messagingrepo.ThreadCategoryPrimary
+	return nil
+}
+func (s *threadRepoStub) ArchiveThreadForUser(_ context.Context, threadID, userID string) error {
+	if threadID != s.thread.ID || userID != s.actorID {
+		return errors.New("missing")
+	}
+	s.archived = true
+	return nil
+}


### PR DESCRIPTION
## Scope on `fix/fph-go-live`

This branch is a go-live reconciliation bundle, not a single-ticket PR.

Included ticket outcomes:
- `FRO-192` — completed on branch, commit `04ac4fd`
- `FRO-195` — completed on branch, commit `aa2b85e`
- `FRO-196` — completed on branch, commit `42bd429`
- `FRO-197` — verified on branch with no code change
- `FRO-199` — completed on branch, commit `1f78e55`
- `FRO-200` — completed on branch, commit `e93d88f`
- `FRO-198` — completed on branch, commit `1dcc40d`
- `FRO-212` — bookkeeping-only reconciliation of execution log truth, commit `beacb1e`

Still open outside merge scope:
- `FRO-191` — blocked by missing runtime/storage truth for end-to-end media verification
- `FRO-213` — target environment app/API availability failure discovered during smoke processing

## Ticket-by-ticket

### FRO-192
- Outcome: recipient-side message request accept/decline flow added in real UI/backend path
- Commit: `04ac4fd`

### FRO-195
- Outcome: restricted group membership narrowed to truthful launch scope; approval-queue fiction removed from web UI
- Commit: `aa2b85e`

### FRO-196
- Outcome: Chika privacy behavior verified; report action exposed in thread/comment UI
- Commit: `42bd429`

### FRO-197
- Outcome: verified-no-code-change; feed strategy and homepage framing already stable on branch
- Verification only: `go test ./internal/features/feed/service` and targeted home-feed type-check

### FRO-199
- Outcome: production media config now fails fast instead of silently disabling upload/signing behavior
- Commit: `1f78e55`

### FRO-200
- Outcome: non-launch `comingSoon` routes removed from launch-visible navigation
- Commit: `e93d88f`

### FRO-198
- Outcome: real go-live smoke checklist added and grounded in current repo truth
- Commit: `1dcc40d`

### FRO-212
- Outcome: reconciled `docs/go-live/fph-execution-log.md` with actual git/Linear truth
- Commit: `beacb1e`

## Smoke status

Environment used for smoke probing:
- configured deploy targets from `render.yaml`
- `https://freediving-ph-api.onrender.com`
- `https://freediving-ph-app.onrender.com`

Observed public responses on 2026-04-01 Asia/Manila:
- `GET https://freediving-ph-api.onrender.com/healthz` -> `404 Not Found`
- `GET https://freediving-ph-api.onrender.com/readyz` -> `404 Not Found`
- `GET https://freediving-ph-api.onrender.com/v1/explore/sites` -> `404 Not Found`
- `GET https://freediving-ph-app.onrender.com/` -> `404 Not Found`
- response headers included `x-render-routing: no-server`

Smoke matrix:
- Clerk sign-in: `blocked` — target web app URL is not serving an app, so no real sign-in path exists to test
- Media upload/readback: `blocked` — target app/API unavailable; no authenticated deployed session; `FRO-191` remains blocked
- Two-account messaging: `blocked` — target app/API unavailable; no deploy-time auth context; no two-account proof possible
- Explore live path: `failed` — public API probe to `/v1/explore/sites` returned `404`
- Overall checklist state: `failed / blocked` — target environment is not currently available for truthful go-live verification

## Merge readiness
- Reviewable branch: yes
- Ticket commits accounted for: yes
- Linear review state aligned: yes for processed tickets
- Known follow-ups documented: yes
- Merge-ready for code review: yes

## Go-live readiness
- Go-live ready: no
- Reasons:
  - target environment app/API endpoints are returning `404`
  - real Clerk sign-in not proven
  - real media upload/readback not proven
  - two-account messaging not proven
  - `FRO-191` remains blocked
  - `FRO-213` now tracks deploy availability failure

## Post-merge required actions
1. Resolve `FRO-213` so the configured target web and API URLs actually serve the app/service
2. Re-run `docs/go-live/fph-launch-smoke-checklist.md` against the live target environment
3. Resolve `FRO-191` only with real runtime/storage verification evidence
4. Confirm target-environment Clerk sign-in, media upload/readback, and two-account messaging before any public launch claim
